### PR TITLE
[WIP] test: Only run stable tests for pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    name: tests
+    name: all tests
     runs-on: [self-hosted, linux]
     steps:
       # Install and setup go
@@ -32,7 +32,11 @@ jobs:
       #     docker rm -f $(docker ps -a -q) || true
       #     docker network prune -f || true
 
-      # run tests
-      - name: run all tests
-        # show cosmos chain and relayer logs on test failure
-        run: (go test -timeout 30m -v -p 2 ./...) || (echo "\n\n*****CHAIN and RELAYER LOGS*****" && cat "$HOME/.ibctest/logs/ibctest.log" && exit 1)
+      - name: unit tests
+        run: make test
+
+      - name: e2e test
+        # On test failure, clean test cache and show cosmos chain and relayer logs.
+        run: >
+          (go test -timeout 30m -v -p 2 -run=TestRelayer ./cmd/ibctest) || 
+          (go clean -testcache && echo "\n\n*****CHAIN and RELAYER LOGS*****" && cat "$HOME/.ibctest/logs/ibctest.log" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ibctest: ## Build ibctest binary into ./bin
 
 .PHONY: test
 test: ## Run unit tests
-	@go test -cover -short -race -timeout=60s $(shell go list ./... | grep -v /cmd/)
+	@go test -cover -short -race -timeout=60s ./...
 
 .PHONY: docker-reset
 docker-reset: ## Attempt to delete all running containers. Useful if ibctest does not exit cleanly.

--- a/cmd/ibctest/ibctest_test.go
+++ b/cmd/ibctest/ibctest_test.go
@@ -168,6 +168,10 @@ func getCustomChainFactory(customChainSet []ibctest.CustomChainFactoryEntry, log
 // if this is too taxing on a system, the -test.parallel flag
 // can be used to reduce how many tests actively run at once.
 func TestRelayer(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	t.Parallel()
 
 	logger, err := extraFlags.Logger()


### PR DESCRIPTION
# Description, Motivation, and Context

Note: This PR is a proposal and I'm happy to debate and close if necessary.

Tests for PRs should be stable to prevent toil and protect developer productivity. 

This removes Penumbra from running on CI PRs. This error has blocked several PRs as of this writing. 

The failure seems to be internal to penumbra:

```
error generating wallet on penumbra node: container returned non-zero error code: 1
```

## Known Limitations, Trade-offs, Tech Debt
* When do we test other chains? See https://github.com/strangelove-ventures/ibc-test-framework/issues/80#issue-1235714793