### PR TITLE
Add test labels

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -20,6 +20,11 @@ var knownTestLabels = map[Test]struct{}{
 	TimestampTimeout: {},
 }
 
+func (l Test) IsKnown() bool {
+	_, exists := knownTestLabels[l]
+	return exists
+}
+
 // Relayer is a label associated with a relayer during tests.
 // Relayer values must be registered through RegisterRelayerLabel, typically inside init functions.
 type Relayer string
@@ -32,6 +37,11 @@ const (
 var knownRelayerLabels = map[Relayer]struct{}{
 	Rly:    {},
 	Hermes: {},
+}
+
+func (l Relayer) IsKnown() bool {
+	_, exists := knownRelayerLabels[l]
+	return exists
 }
 
 // RegisterRelayerLabel is available for external packages that may import ibctest,

--- a/label/label.go
+++ b/label/label.go
@@ -1,0 +1,85 @@
+package label
+
+import (
+	"fmt"
+)
+
+// Test is a label associated with an individual test.
+// All test labels are known at compile time.
+type Test string
+
+const (
+	Timeout          Test = "timeout"
+	HeightTimeout    Test = "height_timeout"
+	TimestampTimeout Test = "timestamp_timeout"
+)
+
+var knownTestLabels = map[Test]struct{}{
+	Timeout:          {},
+	HeightTimeout:    {},
+	TimestampTimeout: {},
+}
+
+// Relayer is a label associated with a relayer during tests.
+// Relayer values must be registered through RegisterRelayerLabel, typically inside init functions.
+type Relayer string
+
+const (
+	Rly    Relayer = "rly"
+	Hermes Relayer = "hermes"
+)
+
+var knownRelayerLabels = map[Relayer]struct{}{
+	Rly:    {},
+	Hermes: {},
+}
+
+// RegisterRelayerLabel is available for external packages that may import ibctest,
+// to register any external relayer implementations they may provide.
+func RegisterRelayerLabel(l Relayer) {
+	if _, exists := knownRelayerLabels[l]; exists {
+		panic(fmt.Errorf("relayer label %q already exists and must not be double registered", l))
+	}
+
+	knownRelayerLabels[l] = struct{}{}
+}
+
+// Chain is a label associated with a chain during tests.
+// Chain values must be registered through RegisterChainLabel, typically inside init functions.
+type Chain string
+
+func (l Chain) IsKnown() bool {
+	_, exists := knownChainLabels[l]
+	return exists
+}
+
+const (
+	// Cosmos-based chains should include this label.
+	Cosmos Chain = "cosmos"
+
+	// Specific chains follow.
+
+	Gaia    Chain = "gaia"
+	Osmosis Chain = "osmosis"
+	Juno    Chain = "juno"
+
+	Penumbra Chain = "penumbra"
+)
+
+var knownChainLabels = map[Chain]struct{}{
+	Gaia:    {},
+	Osmosis: {},
+	Juno:    {},
+
+	Penumbra: {},
+}
+
+// RegisterChainLabel is available for external packages that may import ibctest,
+// to register any external chain implementations they may provide.
+func RegisterChainLabel(l Chain) {
+	if _, exists := knownChainLabels[l]; exists {
+		panic(fmt.Errorf("chain label %q already exists and must not be double registered", l))
+	}
+
+	knownChainLabels[l] = struct{}{}
+}

--- a/relayerfactory.go
+++ b/relayerfactory.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ory/dockertest/v3"
 	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/label"
 	"github.com/strangelove-ventures/ibctest/relayer"
 	"github.com/strangelove-ventures/ibctest/relayer/rly"
 	"go.uber.org/zap"
@@ -24,6 +25,14 @@ type RelayerFactory interface {
 	// Name returns a descriptive name of the factory,
 	// indicating details of the Relayer that will be built.
 	Name() string
+
+	// Labels are reported to allow simple filtering of tests depending on this Relayer.
+	// While the Name should be fully descriptive,
+	// the Labels are intended to be short and fixed.
+	//
+	// Most relayers will probably only have one label indicative of its name,
+	// but we allow multiple labels for future compatibility.
+	Labels() []label.Relayer
 
 	// Capabilities is an indication of the features this relayer supports.
 	// Tests for any unsupported features will be skipped rather than failed.
@@ -74,6 +83,15 @@ func (f builtinRelayerFactory) Name() string {
 		// so that the slashes in the image repository don't add ambiguity
 		// to subtest paths, when the factory name is used in calls to t.Run.
 		return "rly@" + rly.ContainerVersion
+	default:
+		panic(fmt.Errorf("RelayerImplementation %v unknown", f.impl))
+	}
+}
+
+func (f builtinRelayerFactory) Labels() []label.Relayer {
+	switch f.impl {
+	case ibc.CosmosRly:
+		return []label.Relayer{label.Rly}
 	default:
 		panic(fmt.Errorf("RelayerImplementation %v unknown", f.impl))
 	}

--- a/testreporter/messages.go
+++ b/testreporter/messages.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/strangelove-ventures/ibctest/label"
 )
 
 // Message is the sentinel interface to all testreporter messages.
@@ -41,6 +43,15 @@ func (m FinishSuiteMessage) typ() string {
 type BeginTestMessage struct {
 	Name      string
 	StartedAt time.Time
+	Labels    LabelSet
+}
+
+// LabelSet is the set of labels that can be associated with a test.
+type LabelSet struct {
+	Relayer []label.Relayer `json:",omitEmpty"`
+	Chain   []label.Chain   `json:",omitEmpty"`
+
+	Test []label.Test `json:",omitEmpty"`
 }
 
 func (m BeginTestMessage) typ() string {

--- a/testreporter/messages.go
+++ b/testreporter/messages.go
@@ -48,10 +48,10 @@ type BeginTestMessage struct {
 
 // LabelSet is the set of labels that can be associated with a test.
 type LabelSet struct {
-	Relayer []label.Relayer `json:",omitEmpty"`
-	Chain   []label.Chain   `json:",omitEmpty"`
+	Relayer []label.Relayer `json:",omitempty"`
+	Chain   []label.Chain   `json:",omitempty"`
 
-	Test []label.Test `json:",omitEmpty"`
+	Test []label.Test `json:",omitempty"`
 }
 
 func (m BeginTestMessage) typ() string {

--- a/testreporter/messages_test.go
+++ b/testreporter/messages_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/strangelove-ventures/ibctest/label"
 	"github.com/strangelove-ventures/ibctest/testreporter"
 	"github.com/stretchr/testify/require"
 )
@@ -16,7 +17,17 @@ func TestWrappedMessage_RoundTrip(t *testing.T) {
 	}{
 		{Message: testreporter.BeginSuiteMessage{StartedAt: time.Now()}},
 		{Message: testreporter.FinishSuiteMessage{FinishedAt: time.Now()}},
-		{Message: testreporter.BeginTestMessage{Name: "foo", StartedAt: time.Now()}},
+		{
+			Message: testreporter.BeginTestMessage{
+				Name:      "foo",
+				StartedAt: time.Now(),
+				Labels: testreporter.LabelSet{
+					Relayer: []label.Relayer{label.Rly},
+					Chain:   []label.Chain{label.Gaia},
+					Test:    []label.Test{label.Timeout},
+				},
+			},
+		},
 		{Message: testreporter.PauseTestMessage{Name: "foo", When: time.Now()}},
 		{Message: testreporter.ContinueTestMessage{Name: "foo", When: time.Now()}},
 		{Message: testreporter.FinishTestMessage{Name: "foo", FinishedAt: time.Now(), Skipped: true, Failed: true}},

--- a/testreporter/reporter.go
+++ b/testreporter/reporter.go
@@ -72,6 +72,13 @@ func (r *Reporter) Close() error {
 // TrackParameters is intended to be called from the outermost layer of tests.
 // It tracks the test run including labels indicative of what relayers and chains are used.
 func (r *Reporter) TrackParameters(t T, relayerLabels []label.Relayer, chainLabels []label.Chain) {
+	for _, l := range relayerLabels {
+		if !l.IsKnown() {
+			panic(fmt.Errorf("illegal use of unknown relayer label %q", l))
+		}
+	}
+	// Allowing unknown chain labels, for now.
+
 	r.trackTest(t, LabelSet{
 		Relayer: relayerLabels,
 		Chain:   chainLabels,
@@ -80,6 +87,12 @@ func (r *Reporter) TrackParameters(t T, relayerLabels []label.Relayer, chainLabe
 
 // TrackTest tracks execution of a subtest using the supplied labels.
 func (r *Reporter) TrackTest(t T, labels ...label.Test) {
+	for _, l := range labels {
+		if !l.IsKnown() {
+			panic(fmt.Errorf("illegal use of unknown test label %q", l))
+		}
+	}
+
 	r.trackTest(t, LabelSet{
 		Test: labels,
 	})

--- a/testreporter/reporter_test.go
+++ b/testreporter/reporter_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/strangelove-ventures/ibctest/label"
 	"github.com/strangelove-ventures/ibctest/testreporter"
 	"github.com/stretchr/testify/require"
 )
@@ -101,7 +102,7 @@ func TestReporter_TrackPassingSingleTest(t *testing.T) {
 	mt := &mockT{name: "my_test"}
 
 	beforeStartTest := time.Now()
-	r.TrackTest(mt)
+	r.TrackTest(mt, label.Timeout)
 	afterStartTest := time.Now()
 
 	time.Sleep(10 * time.Millisecond)
@@ -122,6 +123,7 @@ func TestReporter_TrackPassingSingleTest(t *testing.T) {
 
 	beginTestMsg := msgs[1].(testreporter.BeginTestMessage)
 	require.Equal(t, beginTestMsg.Name, "my_test")
+	require.Equal(t, beginTestMsg.Labels, testreporter.LabelSet{Test: []label.Test{label.Timeout}})
 	requireTimeInRange(t, beginTestMsg.StartedAt, beforeStartTest, afterStartTest)
 
 	finishTestMsg := msgs[2].(testreporter.FinishTestMessage)


### PR DESCRIPTION
As of this change, labels are associated with individual tests and are
only used for reporting purposes. Filtering tests to run from the
command line is more complex than it might first appear, so that will
happen in a separate change. Label presence in test reports today could
be used for viewing a filtered subset of the report, however.

There are Relayer and Chain labels that are included with top-level
tests, and then individual subtests may have an optional set of labels.
