### PR TITLE
Rename textual occurrences of ibc-test-framework

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,7 @@ jobs:
         with:
           go-version: 1.17
 
-      # checkout ibc-test-framework
-      - name: checkout ibc-test-framework
+      - name: checkout ibctest
         uses: actions/checkout@v2
 
       # cleanup docker environment on self-hosted test runner

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# IBC Test Framework
+# ibctest
 
-The IBC Test Framework orchestrates Go tests that utilize Docker containers for multiple
+ibctest orchestrates Go tests that utilize Docker containers for multiple
 [IBC](https://docs.cosmos.network/master/ibc/overview.html)-compatible blockchains.
 
 ## Focusing on Specific Tests
@@ -41,14 +41,14 @@ the [Go Relayer](https://github.com/cosmos/relayer).
 Alternatively, you can run `ibctest -matrix path/to/matrix.json` to define a set of chains to IBC-test.
 See [`cmd/ibctest/README.md`](cmd/ibctest/README.md) for more details.
 
-Note that `ibc-test-framework` is under active development
+Note that `ibctest` is under active development
 and we are not yet ready to commit to any stable APIs around the testing interfaces.
 
 Please read the [logging style guide](./docs/logging.md).
 
 ## Trophies
 
-Significant bugs that were more easily fixed with the `ibc-test-framework`:
+Significant bugs that were more easily fixed with `ibctest`:
 
-- [Juno network halt reproduction](https://github.com/strangelove-ventures/ibc-test-framework/pull/7)
-- [Juno network halt fix confirmation](https://github.com/strangelove-ventures/ibc-test-framework/pull/8)
+- [Juno network halt reproduction](https://github.com/strangelove-ventures/ibctest/pull/7)
+- [Juno network halt fix confirmation](https://github.com/strangelove-ventures/ibctest/pull/8)

--- a/relayer/capability.go
+++ b/relayer/capability.go
@@ -10,7 +10,7 @@ package relayer
 // Capability indicates a relayer's support of a given feature.
 type Capability int
 
-// The list of relayer capabilities that the ibc-test-framework understands.
+// The list of relayer capabilities that ibctest understands.
 const (
 	TimestampTimeout Capability = iota
 	HeightTimeout

--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -25,7 +25,7 @@
 //     }
 //
 // Although the relayertest package is made available as a convenience for other projects,
-// the ibc-test-framework project should be considered the canonical definition of tests and configuration.
+// the ibctest project should be considered the canonical definition of tests and configuration.
 package relayertest
 
 import (

--- a/test_setup.go
+++ b/test_setup.go
@@ -43,7 +43,7 @@ func SetupTestRun(t *testing.T) (context.Context, string, *dockertest.Pool, stri
 
 	home := t.TempDir()
 
-	networkName := fmt.Sprintf("ibc-test-framework-%s", dockerutil.RandLowerCaseLetterString(8))
+	networkName := fmt.Sprintf("ibctest-%s", dockerutil.RandLowerCaseLetterString(8))
 	network, err := CreateTestNetwork(pool, networkName, t.Name())
 	if err != nil {
 		return ctx, "", nil, "", err

--- a/testreporter/messages.go
+++ b/testreporter/messages.go
@@ -17,7 +17,7 @@ type Message interface {
 type BeginSuiteMessage struct {
 	StartedAt time.Time
 
-	// TODO: it would be nice to embed the ibc-test-framework commit in this message,
+	// TODO: it would be nice to embed the ibctest commit in this message,
 	// but while https://github.com/golang/go/issues/33976 is outstanding,
 	// we'll have to fall back to ldflags to embed it.
 }


### PR DESCRIPTION
All comment and doc changes, except for the string ibc-test-framework
used in dynamic docker network names; changing that should have no
functional effect.
