### PR TITLE
Replace ibctest.SetupTestRun with ibctest.DockerSetup

### DIFF
--- a/chain/penumbra/penumbra_chain_test.go
+++ b/chain/penumbra/penumbra_chain_test.go
@@ -18,6 +18,7 @@ func TestPenumbraChainStart(t *testing.T) {
 	t.Parallel()
 
 	pool, network := ibctest.DockerSetup(t)
+	home := t.TempDir() // Must be before chain cleanup to avoid test error during cleanup.
 
 	log := zap.NewNop()
 	chain, err := ibctest.GetChain(t.Name(), "penumbra", "015-ersa-v2,v0.35.4", "penumbra-1", 4, 1, log)
@@ -30,7 +31,6 @@ func TestPenumbraChainStart(t *testing.T) {
 		}
 	})
 
-	home := t.TempDir()
 	err = chain.Initialize(t.Name(), home, pool, network)
 	require.NoError(t, err, "failed to initialize penumbra chain")
 

--- a/chain/penumbra/penumbra_chain_test.go
+++ b/chain/penumbra/penumbra_chain_test.go
@@ -1,6 +1,7 @@
 package penumbra_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/strangelove-ventures/ibctest"
@@ -15,19 +16,21 @@ func TestPenumbraChainStart(t *testing.T) {
 	}
 
 	t.Parallel()
-	ctx, home, pool, network, err := ibctest.SetupTestRun(t)
-	require.NoErrorf(t, err, "failed to set up test run")
+
+	pool, network := ibctest.DockerSetup(t)
 
 	log := zap.NewNop()
 	chain, err := ibctest.GetChain(t.Name(), "penumbra", "015-ersa-v2,v0.35.4", "penumbra-1", 4, 1, log)
 	require.NoError(t, err, "failed to get penumbra chain")
 
+	ctx := context.Background()
 	t.Cleanup(func() {
 		if err := chain.Cleanup(ctx); err != nil {
 			log.Warn("Chain cleanup failed", zap.String("chain", chain.Config().ChainID), zap.Error(err))
 		}
 	})
 
+	home := t.TempDir()
 	err = chain.Initialize(t.Name(), home, pool, network)
 	require.NoError(t, err, "failed to initialize penumbra chain")
 

--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -189,8 +189,7 @@ func TestRelayer(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactor
 
 	req := require.New(rep.TestifyT(t))
 
-	ctx, home, pool, network, err := ibctest.SetupTestRun(t)
-	req.NoError(err, "failed to set up test run")
+	pool, network := ibctest.DockerSetup(t)
 
 	srcChain, dstChain, err := cf.Pair(t.Name())
 	req.NoError(err, "failed to get chain pair")
@@ -198,6 +197,8 @@ func TestRelayer(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactor
 	var (
 		preRelayerStartFuncs []func([]ibc.ChannelOutput)
 		testCases            []*RelayerTestCase
+
+		ctx = context.Background()
 	)
 
 	for _, testCaseConfig := range relayerTestCaseConfigs {
@@ -225,6 +226,7 @@ func TestRelayer(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactor
 	// funds relayer src and dst wallets on respective chain in genesis
 	// creates a faucet account on the both chains (separate fullnode)
 	// funds faucet accounts in genesis
+	home := t.TempDir()
 	_, channels, err := ibctest.StartChainsAndRelayerFromFactory(t, ctx, rep, pool, network, home, srcChain, dstChain, rf, preRelayerStartFuncs)
 	req.NoError(err, "failed to StartChainsAndRelayerFromFactory")
 


### PR DESCRIPTION
SetupTestRun was slowing me down every time I needed to read through to
understand what it did.

It returned five values, of which three are not very special: the
context was a plain context.Background, the home directory was the
result of t.TempDir(), and a returned error was intended to always
result in a test failure.

The new ibctest.DockerSetup method returns a *dockertest.Pool and a
networkID value. Because it already accepted a *testing.T, any errors
during Docker setup will cause a call to t.Fatal to immediately fail the
test, as the test cannot continue without those Docker values.

The previously returned context and home directory are instead created
in the calling test where needed. I find this clearer.

This change also inlines the previously exported CreateNetwork function
which is only called internally from DockerSetup.

