### PR TITLE
Extract ibctest.chainSet type to simplify future tests

### DIFF
--- a/chainset.go
+++ b/chainset.go
@@ -1,0 +1,136 @@
+package ibctest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/ory/dockertest/v3"
+	"github.com/strangelove-ventures/ibctest/ibc"
+	"golang.org/x/sync/errgroup"
+)
+
+// chainSet is an ordered collection of ibc.Chain,
+// to group methods that apply actions against all chains in the set.
+//
+// The main purpose of the chainSet is to unify test setup when working with any number of chains.
+type chainSet []ibc.Chain
+
+// Initialize concurrently calls Initialize against each chain in the set.
+// Each chain may run a docker pull command,
+// so with a cold image cache, running concurrently may save some time.
+func (cs chainSet) Initialize(testName string, homeDir string, pool *dockertest.Pool, networkID string) error {
+	var eg errgroup.Group
+
+	for _, c := range cs {
+		c := c
+		eg.Go(func() error {
+			if err := c.Initialize(testName, homeDir, pool, networkID); err != nil {
+				return fmt.Errorf("failed to initialize chain %s: %w", c.Config().Name, err)
+			}
+
+			return nil
+		})
+	}
+
+	return eg.Wait()
+}
+
+// CreateKeys creates an ephemeral key for each chain in the set,
+// returning the appropriate bech32 version of the key
+// and the mnemonic behind it.
+func (cs chainSet) CreateKeys() (bech32Addresses, mnemonics []string, err error) {
+	bech32Addresses = make([]string, len(cs))
+	mnemonics = make([]string, len(cs))
+
+	kr := keyring.NewInMemory()
+
+	// NOTE: this is hardcoded to the cosmos coin type.
+	// In the future, we may need to get the coin type from the chain config.
+	const coinType = types.CoinType
+
+	for i, c := range cs {
+		// The account name doesn't matter because the keyring is ephemeral,
+		// but within the keyring's lifecycle, the name must be unique.
+		accountName := fmt.Sprintf("acct-%d", i)
+
+		info, mnemonic, err := kr.NewMnemonic(
+			accountName,
+			keyring.English,
+			hd.CreateHDPath(coinType, 0, 0).String(),
+			"", // Empty passphrase.
+			hd.Secp256k1,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		bech32Addresses[i] = types.MustBech32ifyAddressBytes(c.Config().Bech32Prefix, info.GetAddress().Bytes())
+		mnemonics[i] = mnemonic
+	}
+
+	return bech32Addresses, mnemonics, nil
+}
+
+// CreateCommonAccount creates a key with the given name on each chain in the set,
+// and returns the bech32 representation of each account created.
+//
+// The keys are created concurrently because creating keys on one chain
+// should have no effect on any other chain.
+func (cs chainSet) CreateCommonAccount(ctx context.Context, keyName string) (bech32 []string, err error) {
+	bech32 = make([]string, len(cs))
+
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	for i, c := range cs {
+		i, c := i, c
+		eg.Go(func() error {
+			config := c.Config()
+
+			if err := c.CreateKey(egCtx, keyName); err != nil {
+				return fmt.Errorf("failed to create key with name %q on chain %s: %w", keyName, config.Name, err)
+			}
+
+			addrBytes, err := c.GetAddress(egCtx, keyName)
+			if err != nil {
+				return fmt.Errorf("failed to get account address for key %q on chain %s: %w", keyName, config.Name, err)
+			}
+
+			bech32[i], err = types.Bech32ifyAddressBytes(config.Bech32Prefix, addrBytes)
+			if err != nil {
+				return fmt.Errorf("failed to Bech32ifyAddressBytes on chain %s: %w", config.Name, err)
+			}
+
+			return nil
+		})
+	}
+
+	return bech32, eg.Wait()
+}
+
+// Start concurrently calls Start against each chain in the set.
+func (cs chainSet) Start(ctx context.Context, testName string, additionalGenesisWallets [][]ibc.WalletAmount) error {
+	if len(additionalGenesisWallets) != len(cs) {
+		panic(fmt.Errorf(
+			"chainSet.Start called with %d additional set(s) of wallets; expected %d to match number of chains",
+			len(additionalGenesisWallets), len(cs),
+		))
+	}
+
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	for i, c := range cs {
+		i, c := i, c
+		eg.Go(func() error {
+			if err := c.Start(testName, egCtx, additionalGenesisWallets[i]...); err != nil {
+				return fmt.Errorf("failed to start chain %s: %w", c.Config().Name, err)
+			}
+
+			return nil
+		})
+	}
+
+	return eg.Wait()
+}

--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -227,8 +227,8 @@ func TestRelayer(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactor
 	// creates a faucet account on the both chains (separate fullnode)
 	// funds faucet accounts in genesis
 	home := t.TempDir()
-	_, channels, err := ibctest.StartChainsAndRelayerFromFactory(t, ctx, rep, pool, network, home, srcChain, dstChain, rf, preRelayerStartFuncs)
-	req.NoError(err, "failed to StartChainsAndRelayerFromFactory")
+	_, channels, err := ibctest.StartChainPairAndRelayer(t, ctx, rep, pool, network, home, srcChain, dstChain, rf, preRelayerStartFuncs)
+	req.NoError(err, "failed to StartChainPairAndRelayer")
 
 	// TODO poll for acks inside of each testCase `.Config.Test` method instead of just waiting for blocks here
 	// Wait for both chains to produce 10 blocks per test case.

--- a/test_setup.go
+++ b/test_setup.go
@@ -92,6 +92,9 @@ func StartChainPairAndRelayer(
 
 	// Create addresses out of band, because the chain genesis needs to know where to send initial funds.
 	addresses, mnemonics, err := cs.CreateKeys()
+	if err != nil {
+		return errResponse(err)
+	}
 
 	// Fund relayer account on src chain
 	srcRelayerWalletAmount := ibc.WalletAmount{


### PR DESCRIPTION
The StartChainsAndRelayerFromFactory function, which has now been
renamed to StartChainPairAndRelayer, had some lengthy sections to set up
chains in preparation for tests. The logic in those sections would apply
just the same to three or more chains. We are working towards supporting
tests beyond a single pair of chains, so extract that common behavior
into the new chainSet type.

The chainSet type is unexported for now, as it contains behavior that
was internal to the StartChainsAndRelayerFromFactory function.
