### PR TITLE
Add TrackSkip method to test reporter

### DIFF
--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -101,13 +101,14 @@ var relayerTestCaseConfigs = [...]RelayerTestCaseConfig{
 	},
 }
 
-func requireCapabilities(t *testing.T, rf ibctest.RelayerFactory, reqCaps ...relayer.Capability) {
+// requireCapabilities tracks skipping t, if the relayer factory cannot satisfy the required capabilities.
+func requireCapabilities(t *testing.T, rep *testreporter.Reporter, rf ibctest.RelayerFactory, reqCaps ...relayer.Capability) {
 	t.Helper()
 
 	missing := missingCapabilities(rf, reqCaps...)
 
 	if len(missing) > 0 {
-		t.Skipf("skipping due to missing capabilities +%s", missing)
+		rep.TrackSkip(t, "skipping due to missing relayer capabilities +%s", missing)
 	}
 }
 
@@ -241,7 +242,7 @@ func TestRelayer(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactor
 		testCase := testCase
 		t.Run(testCase.Config.Name, func(t *testing.T) {
 			rep.TrackTest(t, testCase.Config.TestLabels...)
-			requireCapabilities(t, rf, testCase.Config.RequiredRelayerCapabilities...)
+			requireCapabilities(t, rep, rf, testCase.Config.RequiredRelayerCapabilities...)
 			rep.TrackParallel(t)
 			testCase.Config.Test(ctx, t, testCase, rep, srcChain, dstChain, channels)
 		})

--- a/testreporter/doc.go
+++ b/testreporter/doc.go
@@ -44,6 +44,17 @@
 //       // Normal test usage continues...
 //     }
 //
+// If a test needs to be skipped, the TrackSkip method will track the skip reason.
+// Like the other Track methods, calling t.Skip directly will still cause the test to be skipped,
+// and the reporter will note that the test was skipped,
+// but the reporter would not track the specific skip reason.
+//
+//     func TestFooSkip(t *testing.T) {
+//       if someReason() {
+//         reporter.TrackSkip(t, "skipping due to %s", whySkipped())
+//       }
+//     }
+//
 // Lastly, and perhaps most importantly, the reporter is designed to integrate
 // with testify's require and assert packages.
 // Plain "go test" runs simply have a stream of log lines and a failure/skip state.

--- a/testreporter/messages.go
+++ b/testreporter/messages.go
@@ -107,6 +107,18 @@ func (m TestErrorMessage) typ() string {
 	return "TestError"
 }
 
+// TestSkipMessage is tracked when a Reporter's TrackSkip method is called.
+// This allows the report to track the reason a test was skipped.
+type TestSkipMessage struct {
+	Name    string
+	When    time.Time
+	Message string
+}
+
+func (m TestSkipMessage) typ() string {
+	return "TestSkip"
+}
+
 // RelayerExecMessage is the result of executing a relayer command.
 // This message is populated through the RelayerExecReporter type,
 // which is returned by the Reporter's RelayerExecReporter method.
@@ -186,6 +198,10 @@ func (m *WrappedMessage) UnmarshalJSON(b []byte) error {
 		msg = x
 	case "TestError":
 		x := TestErrorMessage{}
+		err = json.Unmarshal(raw, &x)
+		msg = x
+	case "TestSkip":
+		x := TestSkipMessage{}
 		err = json.Unmarshal(raw, &x)
 		msg = x
 	case "RelayerExec":

--- a/testreporter/messages_test.go
+++ b/testreporter/messages_test.go
@@ -32,6 +32,7 @@ func TestWrappedMessage_RoundTrip(t *testing.T) {
 		{Message: testreporter.ContinueTestMessage{Name: "foo", When: time.Now()}},
 		{Message: testreporter.FinishTestMessage{Name: "foo", FinishedAt: time.Now(), Skipped: true, Failed: true}},
 		{Message: testreporter.TestErrorMessage{Name: "foo", When: time.Now(), Message: "something failed"}},
+		{Message: testreporter.TestSkipMessage{Name: "foo", When: time.Now(), Message: "skipped for reasons"}},
 		{
 			Message: testreporter.RelayerExecMessage{
 				Name:          "foo",

--- a/testreporter/reporter.go
+++ b/testreporter/reporter.go
@@ -15,6 +15,8 @@ type T interface {
 	Name() string
 	Cleanup(func())
 
+	Skip(...interface{})
+
 	Parallel()
 
 	Failed() bool
@@ -131,6 +133,21 @@ func (r *Reporter) TrackParallel(t T) {
 		Name: name,
 		When: time.Now(),
 	}
+}
+
+// TrackSkip records a the reason for a test being skipped,
+// and calls t.Skip.
+func (r *Reporter) TrackSkip(t T, format string, args ...interface{}) {
+	now := time.Now()
+	msg := fmt.Sprintf(format, args...)
+
+	r.in <- TestSkipMessage{
+		Name:    t.Name(),
+		When:    now,
+		Message: msg,
+	}
+
+	t.Skip(msg)
 }
 
 // RelayerExecReporter returns a RelayerExecReporter associated with t.


### PR DESCRIPTION
We now track missing relayer capabilities as the reason when tests are
skipped for that. If and when we skip tests based on label filtering,
that will also use this new method.
