### PR TITLE
Reorganize test hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,29 +8,29 @@ ibctest orchestrates Go tests that utilize Docker containers for multiple
 You may focus on a specific tests using the `-test.run=<regex>` flag.
 
 ```shell
-ibctest -test.run=/<relayer>/<chain combination>/<test name>
+ibctest -test.run=/<test category>/<chain combination>/<relayer>/<test name>
 ```
 
 If you want to focus on a specific test:
 
 ```shell
-ibctest -test.run=///relay_packet
-ibctest -test.run=///no_timeout
-ibctest -test.run=///height_timeout
-ibctest -test.run=///timestamp_timeout
+ibctest -test.run=////relay_packet
+ibctest -test.run=////no_timeout
+ibctest -test.run=////height_timeout
+ibctest -test.run=////timestamp_timeout
 ```
 
 Example of narrowing your focus even more:
 
 ```shell
 # run all tests for Go relayer
-ibctest -test.run=/rly//
+ibctest -test.run=///rly/
 
 # run all tests for Go relayer and gaia chains
-ibctest -test.run=/rly/gaia/
+ibctest -test.run=//gaia/rly/
 
 # only run no_timeout test for Go relayer and gaia chains
-ibctest -test.run=/rly/gaia/no_timeout
+ibctest -test.run=//gaia/rly/no_timeout
 ```
 
 ## Contributing

--- a/cmd/ibctest/ibctest_test.go
+++ b/cmd/ibctest/ibctest_test.go
@@ -163,11 +163,11 @@ func getCustomChainFactory(customChainSet []ibctest.CustomChainFactoryEntry, log
 	return ibctest.NewCustomChainFactory(customChainSet, logger), nil
 }
 
-// TestRelayer is the root test for the relayer.
-// It runs each subtest in parallel;
+// TestConformance is the root test for the ibc conformance tests.
+// It runs many subtests in parallel;
 // if this is too taxing on a system, the -test.parallel flag
 // can be used to reduce how many tests actively run at once.
-func TestRelayer(t *testing.T) {
+func TestConformance(t *testing.T) {
 	t.Parallel()
 
 	logger, err := extraFlags.Logger()
@@ -209,7 +209,7 @@ func TestRelayer(t *testing.T) {
 	}
 
 	// Begin test execution, which will spawn many parallel subtests.
-	relayertest.TestRelayerChainCombinations(t, chainFactories, relayerFactories, reporter)
+	relayertest.TestConformance(t, chainFactories, relayerFactories, reporter)
 }
 
 // addFlags configures additional flags beyond the default testing flags.

--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -184,13 +184,14 @@ func sendIBCTransfersFromBothChainsWithTimeout(
 	testCase.TxCache = []ibc.Tx{srcTx, dstTx}
 }
 
-// TestRelayer is the stable API exposed by the relayertest package.
+// TestConformance is the stable API exposed by the relayertest package.
 // This is intended to be used by Go unit tests.
 //
 // This function accepts the full set of chain factories and relayer factories to use,
 // so that it can properly group subtests in a single invocation.
-// If this does not meet your needs, you can directly call e.g. TestRelayer_Pair.
-func TestRelayerChainCombinations(t *testing.T, cfs []ibctest.ChainFactory, rfs []ibctest.RelayerFactory, rep *testreporter.Reporter) {
+// If the subtest configuration does not meet your needs,
+// you can directly call one of the other exported Test functions, such as TestChainPair.
+func TestConformance(t *testing.T, cfs []ibctest.ChainFactory, rfs []ibctest.RelayerFactory, rep *testreporter.Reporter) {
 	// Validate chain factory counts up front.
 	counts := make(map[int]bool)
 	for _, cf := range cfs {
@@ -220,7 +221,7 @@ func TestRelayerChainCombinations(t *testing.T, cfs []ibctest.ChainFactory, rfs 
 							rep.TrackParameters(t, rf.Labels(), cf.Labels())
 							rep.TrackParallel(t)
 
-							TestRelayer_Pair(t, cf, rf, rep)
+							TestChainPair(t, cf, rf, rep)
 						})
 					}
 				})
@@ -229,7 +230,11 @@ func TestRelayerChainCombinations(t *testing.T, cfs []ibctest.ChainFactory, rfs 
 	}
 }
 
-func TestRelayer_Pair(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory, rep *testreporter.Reporter) {
+// TestChainPair runs the conformance tests for two chains and one relayer.
+// This function is exported in case there is a third party that needs to run this test
+// without the parallel subtests structure from TestConformance,
+// but the stability of this API and even the existence of this function is not guaranteed.
+func TestChainPair(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory, rep *testreporter.Reporter) {
 	pool, network := ibctest.DockerSetup(t)
 
 	req := require.New(rep.TestifyT(t))


### PR DESCRIPTION
The old way was ROOT/$relayer/$chains/$subtests. The new organization is
ROOT/$arity/$chains/$relayer/$subtests.

In the new layout, $arity currently has one possible value, "pairs".
Although we have discussed the possibility of supporting "triplets" as
an arity, it is not currently on the roadmap for compliance tests.
Leaving arity as part of the test hierarchy keeps that option open
without incurring a command-line API change. (We could also have IBC
configuration tests against a single chain, if that need arises.)

Also of note, this organizes $chains before $relayer. I think this is
more in the spirit of what ibctest is providing. The previous layout was
asking the question, "Does relayer X properly relay for chains A and B,
and for chains C and D?" The new layout asks, "For chains A and B, does
IBC work with relayer X, and for relayer Y?"

To achieve the hierarchy reorganization, the ibctest.ChainFactory
interface was adjusted to replace the Pair method with a Count() method
to inspect how many chains the factory will produce, and a Chains()
method to retrieve all the chains. The previously implemented GetChains
method was removed because a factory will produce a fixed number of
chains; to only accept a subset of the chains would violate the
factory's expectations.
