### PR TITLE
Initial implementation of ibctest.Interchain

### DIFF
--- a/chainset.go
+++ b/chainset.go
@@ -3,20 +3,19 @@ package ibctest
 import (
 	"context"
 	"fmt"
+	"sync"
 
-	"github.com/cosmos/cosmos-sdk/crypto/hd"
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/ory/dockertest/v3"
 	"github.com/strangelove-ventures/ibctest/ibc"
 	"golang.org/x/sync/errgroup"
 )
 
-// chainSet is an ordered collection of ibc.Chain,
+// chainSet is an unordered collection of ibc.Chain,
 // to group methods that apply actions against all chains in the set.
 //
 // The main purpose of the chainSet is to unify test setup when working with any number of chains.
-type chainSet []ibc.Chain
+type chainSet map[ibc.Chain]struct{}
 
 // Initialize concurrently calls Initialize against each chain in the set.
 // Each chain may run a docker pull command,
@@ -24,7 +23,7 @@ type chainSet []ibc.Chain
 func (cs chainSet) Initialize(testName string, homeDir string, pool *dockertest.Pool, networkID string) error {
 	var eg errgroup.Group
 
-	for _, c := range cs {
+	for c := range cs {
 		c := c
 		eg.Go(func() error {
 			if err := c.Initialize(testName, homeDir, pool, networkID); err != nil {
@@ -38,54 +37,20 @@ func (cs chainSet) Initialize(testName string, homeDir string, pool *dockertest.
 	return eg.Wait()
 }
 
-// CreateKeys creates an ephemeral key for each chain in the set,
-// returning the appropriate bech32 version of the key
-// and the mnemonic behind it.
-func (cs chainSet) CreateKeys() (bech32Addresses, mnemonics []string, err error) {
-	bech32Addresses = make([]string, len(cs))
-	mnemonics = make([]string, len(cs))
-
-	kr := keyring.NewInMemory()
-
-	// NOTE: this is hardcoded to the cosmos coin type.
-	// In the future, we may need to get the coin type from the chain config.
-	const coinType = types.CoinType
-
-	for i, c := range cs {
-		// The account name doesn't matter because the keyring is ephemeral,
-		// but within the keyring's lifecycle, the name must be unique.
-		accountName := fmt.Sprintf("acct-%d", i)
-
-		info, mnemonic, err := kr.NewMnemonic(
-			accountName,
-			keyring.English,
-			hd.CreateHDPath(coinType, 0, 0).String(),
-			"", // Empty passphrase.
-			hd.Secp256k1,
-		)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		bech32Addresses[i] = types.MustBech32ifyAddressBytes(c.Config().Bech32Prefix, info.GetAddress().Bytes())
-		mnemonics[i] = mnemonic
-	}
-
-	return bech32Addresses, mnemonics, nil
-}
-
 // CreateCommonAccount creates a key with the given name on each chain in the set,
 // and returns the bech32 representation of each account created.
+// The typical use of CreateCommonAccount is to create a faucet account on each chain.
 //
 // The keys are created concurrently because creating keys on one chain
 // should have no effect on any other chain.
-func (cs chainSet) CreateCommonAccount(ctx context.Context, keyName string) (bech32 []string, err error) {
-	bech32 = make([]string, len(cs))
+func (cs chainSet) CreateCommonAccount(ctx context.Context, keyName string) (bech32 map[ibc.Chain]string, err error) {
+	var mu sync.Mutex
+	bech32 = make(map[ibc.Chain]string, len(cs))
 
 	eg, egCtx := errgroup.WithContext(ctx)
 
-	for i, c := range cs {
-		i, c := i, c
+	for c := range cs {
+		c := c
 		eg.Go(func() error {
 			config := c.Config()
 
@@ -98,33 +63,34 @@ func (cs chainSet) CreateCommonAccount(ctx context.Context, keyName string) (bec
 				return fmt.Errorf("failed to get account address for key %q on chain %s: %w", keyName, config.Name, err)
 			}
 
-			bech32[i], err = types.Bech32ifyAddressBytes(config.Bech32Prefix, addrBytes)
+			b32, err := types.Bech32ifyAddressBytes(config.Bech32Prefix, addrBytes)
 			if err != nil {
 				return fmt.Errorf("failed to Bech32ifyAddressBytes on chain %s: %w", config.Name, err)
 			}
+
+			mu.Lock()
+			bech32[c] = b32
+			mu.Unlock()
 
 			return nil
 		})
 	}
 
-	return bech32, eg.Wait()
+	if err := eg.Wait(); err != nil {
+		return nil, fmt.Errorf("failed to create common account with name %s: %w", keyName, err)
+	}
+
+	return bech32, nil
 }
 
 // Start concurrently calls Start against each chain in the set.
-func (cs chainSet) Start(ctx context.Context, testName string, additionalGenesisWallets [][]ibc.WalletAmount) error {
-	if len(additionalGenesisWallets) != len(cs) {
-		panic(fmt.Errorf(
-			"chainSet.Start called with %d additional set(s) of wallets; expected %d to match number of chains",
-			len(additionalGenesisWallets), len(cs),
-		))
-	}
-
+func (cs chainSet) Start(ctx context.Context, testName string, additionalGenesisWallets map[ibc.Chain][]ibc.WalletAmount) error {
 	eg, egCtx := errgroup.WithContext(ctx)
 
-	for i, c := range cs {
-		i, c := i, c
+	for c := range cs {
+		c := c
 		eg.Go(func() error {
-			if err := c.Start(testName, egCtx, additionalGenesisWallets[i]...); err != nil {
+			if err := c.Start(testName, egCtx, additionalGenesisWallets[c]...); err != nil {
 				return fmt.Errorf("failed to start chain %s: %w", c.Config().Name, err)
 			}
 

--- a/ibc/Relayer.go
+++ b/ibc/Relayer.go
@@ -49,6 +49,14 @@ type Relayer interface {
 
 	// relay queue until it is empty
 	ClearQueue(ctx context.Context, rep RelayerExecReporter, pathName string, channelID string) error
+
+	// UseDockerNetwork reports whether the relayer is run in the same docker network as the other chains.
+	//
+	// If false, the relayer will connect to the localhost-exposed ports instead of the docker hosts.
+	//
+	// Relayer implementations provided by the ibctest module will report true,
+	// but custom implementations may report false.
+	UseDockerNetwork() bool
 }
 
 // ExecReporter is the interface of a narrow type returned by testreporter.RelayerExecReporter.

--- a/interchain.go
+++ b/interchain.go
@@ -186,8 +186,9 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 	for r, chains := range ic.relayerChains() {
 		for _, c := range chains {
 			rpcAddr, grpcAddr := c.GetRPCAddress(), c.GetGRPCAddress()
-			// TODO: handle relayer outside of Docker
-			// (the UseDockerNetwork() method is on the factory, not the relayer).
+			if !r.UseDockerNetwork() {
+				rpcAddr, grpcAddr = c.GetHostRPCAddress(), c.GetHostGRPCAddress()
+			}
 
 			chainName := ic.chains[c]
 			if err := r.AddChainConfiguration(ctx,

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -407,3 +407,8 @@ func (relayer *CosmosRelayer) Bind() []string {
 func (relayer *CosmosRelayer) stopContainer() error {
 	return relayer.pool.Client.StopContainer(relayer.container.ID, uint(time.Second*30))
 }
+
+// UseDockerNetwork reports true because the cosmos relayer runs in docker.
+func (relayer *CosmosRelayer) UseDockerNetwork() bool {
+	return true
+}

--- a/relayerfactory.go
+++ b/relayerfactory.go
@@ -37,11 +37,6 @@ type RelayerFactory interface {
 	// Capabilities is an indication of the features this relayer supports.
 	// Tests for any unsupported features will be skipped rather than failed.
 	Capabilities() map[relayer.Capability]bool
-
-	// UseDockerNetwork reports whether the relayer is run in the same docker network as the other chains.
-	//
-	// If false, the relayer will connect to the localhost-exposed ports instead of the docker hosts.
-	UseDockerNetwork() bool
 }
 
 // builtinRelayerFactory is the built-in relayer factory that understands
@@ -106,9 +101,4 @@ func (f builtinRelayerFactory) Capabilities() map[relayer.Capability]bool {
 	default:
 		panic(fmt.Errorf("RelayerImplementation %v unknown", f.impl))
 	}
-}
-
-// UseDockerNetwork reports true.
-func (f builtinRelayerFactory) UseDockerNetwork() bool {
-	return true
 }

--- a/test_setup.go
+++ b/test_setup.go
@@ -82,13 +82,13 @@ func StartChainPairAndRelayer(
 	}
 
 	w := NewWorld().
-		AddChain("src", srcChain).
-		AddChain("dst", dstChain).
-		AddRelayer("r", relayerImpl).
+		AddChain(srcChain, "src").
+		AddChain(dstChain, "dst").
+		AddRelayer(relayerImpl, "r").
 		AddLink(WorldLink{
-			Chain1:  "src",
-			Chain2:  "dst",
-			Relayer: "r",
+			Chain1:  srcChain,
+			Chain2:  dstChain,
+			Relayer: relayerImpl,
 			Path:    testPathName,
 		})
 

--- a/test_setup.go
+++ b/test_setup.go
@@ -82,8 +82,8 @@ func StartChainPairAndRelayer(
 	}
 
 	w := NewWorld().
-		AddChain(srcChain, "src").
-		AddChain(dstChain, "dst").
+		AddChain(srcChain).
+		AddChain(dstChain).
 		AddRelayer(relayerImpl, "r").
 		AddLink(WorldLink{
 			Chain1:  srcChain,

--- a/test_setup.go
+++ b/test_setup.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	testPathName      = "test-path"
+	testPathName = "test-path"
 
 	FaucetAccountKeyName = "faucet"
 )
@@ -92,13 +92,12 @@ func StartChainPairAndRelayer(
 		})
 
 	eRep := rep.RelayerExecReporter(t)
-	_, err := ic.Build(ctx, eRep, InterchainBuildOptions{
+	if err := ic.Build(ctx, eRep, InterchainBuildOptions{
 		TestName:  t.Name(),
 		HomeDir:   home,
 		Pool:      pool,
 		NetworkID: networkID,
-	})
-	if err != nil {
+	}); err != nil {
 		return errResponse(err)
 	}
 

--- a/test_setup.go
+++ b/test_setup.go
@@ -80,11 +80,11 @@ func StartChainPairAndRelayer(
 		return nil, []ibc.ChannelOutput{}, err
 	}
 
-	w := NewWorld().
+	ic := NewInterchain().
 		AddChain(srcChain).
 		AddChain(dstChain).
 		AddRelayer(relayerImpl, "r").
-		AddLink(WorldLink{
+		AddLink(InterchainLink{
 			Chain1:  srcChain,
 			Chain2:  dstChain,
 			Relayer: relayerImpl,
@@ -92,7 +92,7 @@ func StartChainPairAndRelayer(
 		})
 
 	eRep := rep.RelayerExecReporter(t)
-	res, err := w.Build(ctx, eRep, WorldBuildOptions{
+	_, err := ic.Build(ctx, eRep, InterchainBuildOptions{
 		TestName:  t.Name(),
 		HomeDir:   home,
 		Pool:      pool,
@@ -101,7 +101,6 @@ func StartChainPairAndRelayer(
 	if err != nil {
 		return errResponse(err)
 	}
-	_ = res // Probably need to pass the result addresses somewhere.
 
 	channels, err := relayerImpl.GetChannels(ctx, eRep, srcChain.Config().ChainID)
 	if err != nil {

--- a/test_setup.go
+++ b/test_setup.go
@@ -17,10 +17,9 @@ import (
 )
 
 const (
-	srcAccountKeyName    = "src-chain"
-	dstAccountKeyName    = "dst-chain"
-	faucetAccountKeyName = "faucet"
-	testPathName         = "test-path"
+	testPathName      = "test-path"
+
+	FaucetAccountKeyName = "faucet"
 )
 
 // DockerSetup sets up a new dockertest.Pool (which is a client connection

--- a/test_user.go
+++ b/test_user.go
@@ -54,7 +54,7 @@ func GetAndFundTestUsers(
 
 		users = append(users, user)
 
-		err = chain.SendFunds(ctx, faucetAccountKeyName, ibc.WalletAmount{
+		err = chain.SendFunds(ctx, FaucetAccountKeyName, ibc.WalletAmount{
 			Address: user.Bech32Address(chainCfg.Bech32Prefix),
 			Amount:  amount,
 			Denom:   chainCfg.Denom,

--- a/test_user.go
+++ b/test_user.go
@@ -21,8 +21,8 @@ func (u *User) Bech32Address(bech32Prefix string) string {
 	return types.MustBech32ifyAddressBytes(bech32Prefix, u.Address)
 }
 
-// generate user wallet on chain
-func getUserWallet(ctx context.Context, keyName string, chain ibc.Chain) (*User, error) {
+// generateUserWallet creates a new user wallet with the given key name on the given chain.
+func generateUserWallet(ctx context.Context, keyName string, chain ibc.Chain) (*User, error) {
 	if err := chain.CreateKey(ctx, keyName); err != nil {
 		return nil, fmt.Errorf("failed to create key on source chain: %w", err)
 	}
@@ -49,12 +49,12 @@ func GetAndFundTestUsers(
 	for _, chain := range chains {
 		chainCfg := chain.Config()
 		keyName := fmt.Sprintf("%s-%s-%s", keyNamePrefix, chainCfg.ChainID, dockerutil.RandLowerCaseLetterString(3))
-		user, err := getUserWallet(ctx, keyName, chain)
+		user, err := generateUserWallet(ctx, keyName, chain)
 		require.NoError(t, err, "failed to get source user wallet")
 
 		users = append(users, user)
 
-		err = GetFundsFromFaucet(chain, ctx, ibc.WalletAmount{
+		err = chain.SendFunds(ctx, faucetAccountKeyName, ibc.WalletAmount{
 			Address: user.Bech32Address(chainCfg.Bech32Prefix),
 			Amount:  amount,
 			Denom:   chainCfg.Denom,
@@ -71,9 +71,4 @@ func GetAndFundTestUsers(
 	require.NoError(t, test.WaitForBlocks(ctx, 5, chainHeights...), "failed to wait for blocks")
 
 	return users
-}
-
-// get funds from faucet if it was initialized in genesis
-func GetFundsFromFaucet(chain ibc.Chain, ctx context.Context, amount ibc.WalletAmount) error {
-	return chain.SendFunds(ctx, faucetAccountKeyName, amount)
 }

--- a/world.go
+++ b/world.go
@@ -38,9 +38,11 @@ type relayerPath struct {
 	Path    string
 }
 
-// AddChain adds the given chain with the given name to the World.
-// If the given chain or name already exists, AddChain panics.
-func (w *World) AddChain(chain ibc.Chain, name string) *World {
+// AddChain adds the given chain to the world.
+// If the given chain already exists,
+// or if another chain with the same configured name exists, AddChain panics.
+func (w *World) AddChain(chain ibc.Chain) *World {
+	name := chain.Config().Name
 	for c, n := range w.chains {
 		if c == chain {
 			panic(fmt.Errorf("chain %v was already added", c))
@@ -87,10 +89,10 @@ type WorldLink struct {
 // If any validation fails, AddLink panics.
 func (w *World) AddLink(link WorldLink) *World {
 	if _, exists := w.chains[link.Chain1]; !exists {
-		panic(fmt.Errorf("chain %v was never added to World", link.Chain1))
+		panic(fmt.Errorf("chain %s was never added to World", link.Chain1.Config().Name))
 	}
 	if _, exists := w.chains[link.Chain2]; !exists {
-		panic(fmt.Errorf("chain %v was never added to World", link.Chain2))
+		panic(fmt.Errorf("chain %s was never added to World", link.Chain2.Config().Name))
 	}
 	if _, exists := w.relayers[link.Relayer]; !exists {
 		panic(fmt.Errorf("relayer %v was never added to World", link.Relayer))

--- a/world.go
+++ b/world.go
@@ -1,0 +1,315 @@
+package ibctest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/ory/dockertest/v3"
+	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/testreporter"
+)
+
+// World represents a full IBC network, encompassing a collection of
+// one or more chains, one or more relayer instances, and initial account configuration.
+type World struct {
+	chains   map[string]ibc.Chain
+	relayers map[string]ibc.Relayer
+
+	// Key: relayer and path name; Value: the two chains being linked.
+	links map[relayerPath][2]string
+}
+
+// NewWorld returns a new World.
+func NewWorld() *World {
+	return &World{
+		chains:   make(map[string]ibc.Chain),
+		relayers: make(map[string]ibc.Relayer),
+
+		links: make(map[relayerPath][2]string),
+	}
+}
+
+// relayerPath is a tuple of a relayer name and a path name.
+type relayerPath struct {
+	Relayer string
+	Path    string
+}
+
+// AddChain adds the given chain with the given name to the World.
+func (w *World) AddChain(name string, chain ibc.Chain) *World {
+	if _, exists := w.chains[name]; exists {
+		panic(fmt.Errorf("chain with name %q already exists", name))
+	}
+
+	w.chains[name] = chain
+	return w
+}
+
+// AddRelayer adds the given relayer with the given name to the World.
+func (w *World) AddRelayer(name string, relayer ibc.Relayer) *World {
+	if _, exists := w.relayers[name]; exists {
+		panic(fmt.Errorf("relayer with name %q already exists", name))
+	}
+
+	w.relayers[name] = relayer
+	return w
+}
+
+// WorldLink describes a link between two chains,
+// by specifying the chain names, the relayer name,
+// and the name of the path to create.
+type WorldLink struct {
+	// Names of chains involved.
+	Chain1, Chain2 string
+
+	// Name of relayer to use for link.
+	Relayer string
+
+	// Name of path to create.
+	Path string
+}
+
+// AddLink adds the given link to the World.
+// If any validation fails, AddLink panics.
+func (w *World) AddLink(link WorldLink) *World {
+	if _, exists := w.chains[link.Chain1]; !exists {
+		panic(fmt.Errorf("chain with name %q does not exist", link.Chain1))
+	}
+	if _, exists := w.chains[link.Chain2]; !exists {
+		panic(fmt.Errorf("chain with name %q does not exist", link.Chain2))
+	}
+	if _, exists := w.relayers[link.Relayer]; !exists {
+		panic(fmt.Errorf("relayer with name %q does not exist", link.Relayer))
+	}
+
+	if link.Chain1 == link.Chain2 {
+		panic(fmt.Errorf("chain names must be different (both were %q)", link.Chain1))
+	}
+
+	key := relayerPath{
+		Relayer: link.Relayer,
+		Path:    link.Path,
+	}
+
+	if _, exists := w.links[key]; exists {
+		panic(fmt.Errorf("relayer %q already has a path named %q", key.Relayer, key.Path))
+	}
+
+	chains := [2]string{link.Chain1, link.Chain2}
+	if chains[0] > chains[1] {
+		chains[0], chains[1] = chains[1], chains[0]
+	}
+
+	w.links[key] = chains
+	return w
+}
+
+// WorldBuildOptions describes configuration for (*World).Build.
+type WorldBuildOptions struct {
+	TestName string
+	HomeDir  string
+
+	Pool      *dockertest.Pool
+	NetworkID string
+}
+
+// Build creates the defined world.
+func (w *World) Build(ctx context.Context, rep *testreporter.RelayerExecReporter, opts WorldBuildOptions) (*WorldResult, error) {
+	// Collect the set of relayer-chain mappings.
+	relayerChains := w.relayerChains()
+	res := new(WorldResult)
+	res.generateWallets(w.chains, relayerChains)
+
+	// Build a chainSet for chain construction.
+	// However, because the chainSet wants to act like a slice,
+	// and the World wants to act like a map,
+	// we have this hacky chainIndices map to track names to slice index.
+	chainIndices := make(map[string]int, len(w.chains))
+	cs := make(chainSet, 0, len(w.chains))
+	for name, c := range w.chains {
+		chainIndices[name] = len(cs)
+		cs = append(cs, c)
+	}
+
+	// Initialize the chains (pull docker images, etc.).
+	if err := cs.Initialize(opts.TestName, opts.HomeDir, opts.Pool, opts.NetworkID); err != nil {
+		return nil, fmt.Errorf("failed to initialize chains: %w", err)
+	}
+
+	// Start chains from genesis.
+	// This would also be considerably simpler if the chain set was aware of the name->chain mapping.
+	walletsByChain := res.walletsByChain()
+	walletAmounts := make([][]ibc.WalletAmount, len(cs))
+	for name, c := range w.chains {
+		wallets := walletsByChain[name]
+		amounts := make([]ibc.WalletAmount, len(wallets))
+		for i, w := range wallets {
+			amounts[i] = ibc.WalletAmount{
+				Address: w.Address,
+				Denom:   c.Config().Denom,
+				Amount:  10_000_000_000_000, // Every wallet gets 10b units of denom.
+			}
+		}
+		walletAmounts[chainIndices[name]] = amounts
+	}
+
+	if err := cs.Start(ctx, opts.TestName, walletAmounts); err != nil {
+		return nil, fmt.Errorf("failed to start chains: %w", err)
+	}
+
+	// One pass through the chains to configure each relayer
+	// for the chains it should know about.
+	for rName, chains := range w.relayerChains() {
+		for _, cName := range chains {
+			r := w.relayers[rName]
+			c := w.chains[cName]
+			rpcAddr, grpcAddr := c.GetRPCAddress(), c.GetGRPCAddress()
+			// TODO: handle relayer outside of Docker
+			// (the UseDockerNetwork() method is on the factory, not the relayer).
+
+			keyName := cName
+			if err := r.AddChainConfiguration(ctx,
+				rep,
+				c.Config(), keyName,
+				rpcAddr, grpcAddr,
+			); err != nil {
+				return nil, fmt.Errorf("failed to configure relayer %s for chain %s: %w", rName, cName, err)
+			}
+
+			if err := r.RestoreKey(ctx,
+				rep,
+				c.Config().ChainID, keyName,
+				res.RelayerWallets[[2]string{rName, cName}].Mnemonic,
+			); err != nil {
+				return nil, fmt.Errorf("failed to restore key to relayer %s for chain %s: %w", rName, cName, err)
+			}
+		}
+	}
+
+	// For every relayer link, teach the relayer about the link and create the link.
+	for rp, chains := range w.links {
+		r := w.relayers[rp.Relayer]
+		c0 := w.chains[chains[0]]
+		c1 := w.chains[chains[1]]
+		if err := r.GeneratePath(ctx, rep, c0.Config().ChainID, c1.Config().ChainID, rp.Path); err != nil {
+			return nil, fmt.Errorf(
+				"failed to generate path %s on relayer %s between chains %s and %s: %w",
+				rp.Path, rp.Relayer, chains[0], chains[1], err,
+			)
+		}
+
+		if err := r.LinkPath(ctx, rep, rp.Path); err != nil {
+			return nil, fmt.Errorf(
+				"failed to link path %s on relayer %s between chains %s and %s: %w",
+				rp.Path, rp.Relayer, chains[0], chains[1], err,
+			)
+		}
+	}
+
+	return res, nil
+}
+
+// WorldResult describes the addresses and mnemonics
+// of the faucet and relayer wallets created during (*World).Build.
+type WorldResult struct {
+	// Keyed by chain name.
+	FaucetWallets map[string]ibc.RelayerWallet
+
+	// Keyed by [relayer name, chain name].
+	RelayerWallets map[[2]string]ibc.RelayerWallet
+}
+
+// generateWallets builds one faucet wallet on each chain
+// and a wallet on each chain for each relayer.
+func (r *WorldResult) generateWallets(chains map[string]ibc.Chain, relayerChains map[string][]string) {
+	kr := keyring.NewInMemory()
+
+	r.FaucetWallets = make(map[string]ibc.RelayerWallet, len(chains))
+	for name, c := range chains {
+		// The account name doesn't matter because the keyring is ephemeral,
+		// but within the keyring's lifecycle, the name must be unique.
+		accountName := "faucet-" + name
+
+		r.FaucetWallets[name] = buildWallet(kr, accountName, c.Config())
+	}
+
+	r.RelayerWallets = make(map[[2]string]ibc.RelayerWallet, len(relayerChains))
+	for relayer, cs := range relayerChains {
+		for _, c := range cs {
+			accountName := "relayer-" + relayer + "-" + c
+
+			config := chains[c].Config()
+			r.RelayerWallets[[2]string{relayer, c}] = buildWallet(kr, accountName, config)
+		}
+	}
+}
+
+// walletsByChain returns a mapping of chain names to a slice of wallets to create.
+func (r *WorldResult) walletsByChain() map[string][]ibc.RelayerWallet {
+	wallets := make(map[string][]ibc.RelayerWallet, len(r.FaucetWallets))
+
+	// Every chain has a faucet wallet, so this is a new slice for each chain.
+	for c, w := range r.FaucetWallets {
+		wallets[c] = []ibc.RelayerWallet{w}
+	}
+
+	for rc, w := range r.RelayerWallets {
+		c := rc[1]
+		wallets[c] = append(wallets[c], w)
+	}
+
+	return wallets
+}
+
+func buildWallet(kr keyring.Keyring, keyName string, config ibc.ChainConfig) ibc.RelayerWallet {
+	// NOTE: this is hardcoded to the cosmos coin type.
+	// In the future, we may need to get the coin type from the chain config.
+	const coinType = types.CoinType
+
+	info, mnemonic, err := kr.NewMnemonic(
+		keyName,
+		keyring.English,
+		hd.CreateHDPath(coinType, 0, 0).String(),
+		"", // Empty passphrase.
+		hd.Secp256k1,
+	)
+	if err != nil {
+		panic(fmt.Errorf("failed to create mnemonic: %w", err))
+	}
+
+	return ibc.RelayerWallet{
+		Address: types.MustBech32ifyAddressBytes(config.Bech32Prefix, info.GetAddress().Bytes()),
+
+		Mnemonic: mnemonic,
+	}
+}
+
+// relayerChains builds a mapping of relayer names to which chains they connect to.
+// The order of the chains is arbitrary.
+func (w *World) relayerChains() map[string][]string {
+	// Use a Set of chain names first just to avoid deduplication.
+	uniq := make(map[string]map[string]struct{}, len(w.relayers))
+
+	for rp, chains := range w.links {
+		r := rp.Relayer
+		if uniq[r] == nil {
+			uniq[r] = make(map[string]struct{}, 2) // Adding at least 2 chains on it.
+		}
+		uniq[r][chains[0]] = struct{}{}
+		uniq[r][chains[1]] = struct{}{}
+	}
+
+	out := make(map[string][]string, len(uniq))
+	for r, m := range uniq {
+		chains := make([]string, 0, len(m))
+		for chain := range m {
+			chains = append(chains, chain)
+		}
+
+		out[r] = chains
+	}
+	return out
+}

--- a/world.go
+++ b/world.go
@@ -142,7 +142,7 @@ func (w *World) Build(ctx context.Context, rep *testreporter.RelayerExecReporter
 	}
 
 	// Faucet addresses are created separately because they need to be explicitly added to the chains.
-	faucetAddresses, err := cs.CreateCommonAccount(ctx, faucetAccountKeyName)
+	faucetAddresses, err := cs.CreateCommonAccount(ctx, FaucetAccountKeyName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create faucet accounts: %w", err)
 	}


### PR DESCRIPTION
This PR adds the `Interchain`type, which provides a Builder-pattern interface for constructing a network of arbitrary Chains and Relayers with user-controlled relaying paths.

We only have a single use of the type in `ibctest.StartChainPairAndRelayer` so far, but we will continue to use the type as the set of tests expand; and we will maintain this as an exported API so that other projects can trivially construct interchain definitions for IBC testing.