### PR TITLE
Add types and functionality needed to start supporting interchain accounts testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 ibctest.test
 
 /bin
+
+#GoLand project directory
+.idea/

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -38,6 +38,7 @@ import (
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 	libclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 )
 
 // ChainNode represents a node in the test network that is being created
@@ -860,4 +861,74 @@ func (tn *ChainNode) logger() *zap.Logger {
 		zap.String("chain_id", tn.Chain.Config().ChainID),
 		zap.String("test", tn.TestName),
 	)
+}
+
+// RegisterICA will attempt to register an interchain account on the counterparty chain.
+func (tn *ChainNode) RegisterICA(ctx context.Context, address, connectionID string) (string, error) {
+	command := []string{tn.Chain.Config().Bin, "tx", "intertx", "register",
+		"--from", address,
+		"--connection-id", connectionID,
+		"--chain-id", tn.Chain.Config().ChainID,
+		"--home", tn.NodeHome(),
+		"--node", fmt.Sprintf("tcp://%s:26657", tn.Name()),
+		"--keyring-backend", keyring.BackendTest,
+		"-y",
+	}
+
+	exitCode, stdout, stderr, err := tn.NodeJob(ctx, command)
+	if err != nil {
+		return "", dockerutil.HandleNodeJobError(exitCode, stdout, stderr, err)
+	}
+	output := IBCTransferTx{}
+	err = yaml.Unmarshal([]byte(stdout), &output)
+	if err != nil {
+		return "", err
+	}
+	return output.TxHash, nil
+}
+
+// QueryICA will query for an interchain account controlled by the specified address on the counterparty chain.
+func (tn *ChainNode) QueryICA(ctx context.Context, connectionID, address string) (string, error) {
+	command := []string{tn.Chain.Config().Bin, "query", "intertx", "interchainaccounts", connectionID, address,
+		"--chain-id", tn.Chain.Config().ChainID,
+		"--home", tn.NodeHome(),
+		"--node", fmt.Sprintf("tcp://%s:26657", tn.Name())}
+
+	exitCode, stdout, stderr, err := tn.NodeJob(ctx, command)
+	if err != nil {
+		return "", dockerutil.HandleNodeJobError(exitCode, stdout, stderr, err)
+	}
+
+	// at this point stdout should look like this:
+	// interchain_account_address: cosmos1p76n3mnanllea4d3av0v0e42tjj03cae06xq8fwn9at587rqp23qvxsv0j
+	// we split the string at the : and then just grab the address before returning.
+	parts := strings.SplitN(stdout, ":", 2)
+	return strings.TrimSpace(parts[1]), nil
+}
+
+// SendICABankTransfer builds a bank transfer message for a specified address and sends it to the specified
+// interchain account.
+func (tn *ChainNode) SendICABankTransfer(ctx context.Context, connectionID, fromAddr string, amount ibc.WalletAmount) error {
+	msg := fmt.Sprintf(`{
+	"@type":"/cosmos.bank.v1beta1.MsgSend",
+	"from_address":"%s",
+	"to_address":"%s",
+	"amount": [
+	{
+		"denom": "%s",
+		"amount": "%d"
+	}
+	]}`, fromAddr, amount.Address, amount.Denom, amount.Amount)
+
+	command := []string{tn.Chain.Config().Bin, "tx", "intertx", "submit", msg,
+		"--connection-id", connectionID,
+		"--from", fromAddr,
+		"--chain-id", tn.Chain.Config().ChainID,
+		"--home", tn.NodeHome(),
+		"--node", fmt.Sprintf("tcp://%s:26657", tn.Name()),
+		"--keyring-backend", keyring.BackendTest,
+		"-y",
+	}
+
+	return dockerutil.HandleNodeJobError(tn.NodeJob(ctx, command))
 }

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -607,3 +607,19 @@ func (c *CosmosChain) Cleanup(ctx context.Context) error {
 func (c *CosmosChain) Height(ctx context.Context) (uint64, error) {
 	return c.getFullNode().Height(ctx)
 }
+
+// RegisterInterchainAccount will register an interchain account on behalf of the calling chain (controller chain)
+// on the counterparty chain (the host chain).
+func (c *CosmosChain) RegisterInterchainAccount(ctx context.Context, keyName, connectionID string) (string, error) {
+	return c.getFullNode().RegisterICA(ctx, keyName, connectionID)
+}
+
+// SendICABankTransfer will send a bank transfer msg from the fromAddr to the specified address for the given amount and denom.
+func (c *CosmosChain) SendICABankTransfer(ctx context.Context, connectionID, fromAddr string, amount ibc.WalletAmount) error {
+	return c.getFullNode().SendICABankTransfer(ctx, connectionID, fromAddr, amount)
+}
+
+// QueryInterchainAccount will query the interchain account that was created on behalf of the specified address.
+func (c *CosmosChain) QueryInterchainAccount(ctx context.Context, connectionID, address string) (string, error) {
+	return c.getFullNode().QueryICA(ctx, connectionID, address)
+}

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -421,3 +421,18 @@ func (c *PenumbraChain) Cleanup(ctx context.Context) error {
 	}
 	return eg.Wait()
 }
+
+func (c *PenumbraChain) RegisterInterchainAccount(ctx context.Context, keyName, connectionID string) (string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *PenumbraChain) SendICABankTransfer(ctx context.Context, connectionID, fromAddr string, amount ibc.WalletAmount) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *PenumbraChain) QueryInterchainAccount(ctx context.Context, connectionID, address string) (string, error) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/dockerutil/errors.go
+++ b/dockerutil/errors.go
@@ -7,7 +7,7 @@ func HandleNodeJobError(exitCode int, _, _ string, err error) error {
 		return err
 	}
 	if exitCode != 0 {
-		return fmt.Errorf("container returned non-zero error code: %d\n", exitCode)
+		return fmt.Errorf("container returned non-zero error code: %d", exitCode)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/cosmos/cosmos-sdk v0.45.1
 	github.com/cosmos/ibc-go/v3 v3.0.0
 	github.com/davecgh/go-spew v1.1.1
+	github.com/google/go-cmp v0.5.7
 	github.com/ory/dockertest/v3 v3.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tendermint/tendermint v0.34.14
+	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.21.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/tools v0.1.10
@@ -58,7 +60,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/btree v1.0.0 // indirect
-	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
@@ -122,7 +123,6 @@ require (
 	github.com/zondax/hid v0.9.0 // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220307211146-efcb8507fb70 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect

--- a/ibc/Relayer.go
+++ b/ibc/Relayer.go
@@ -39,6 +39,9 @@ type Relayer interface {
 	// get channel IDs for chain
 	GetChannels(ctx context.Context, rep RelayerExecReporter, chainID string) ([]ChannelOutput, error)
 
+	// GetConnections returns a slice of IBC connection details composed of the details for each connection on a specified chain.
+	GetConnections(ctx context.Context, rep RelayerExecReporter, chainID string) (ConnectionOutputs, error)
+
 	// After configuration is initialized, begin relaying.
 	// This method is intended to create a background worker that runs the relayer.
 	// You must call StopRelayer to cleanly stop the relaying.
@@ -49,6 +52,14 @@ type Relayer interface {
 
 	// relay queue until it is empty
 	ClearQueue(ctx context.Context, rep RelayerExecReporter, pathName string, channelID string) error
+
+	// CreateClients performs the client handshake steps necessary for creating a light client
+	// on src that tracks the state of dst, and a light client on dst that tracks the state of src.
+	CreateClients(ctx context.Context, rep RelayerExecReporter, pathName string) error
+
+	// CreateConnections performs the connection handshake steps necessary for creating a connection
+	// between the src and dst chains.
+	CreateConnections(ctx context.Context, rep RelayerExecReporter, pathName string) error
 }
 
 // ExecReporter is the interface of a narrow type returned by testreporter.RelayerExecReporter.

--- a/ibc/chain.go
+++ b/ibc/chain.go
@@ -78,4 +78,14 @@ type Chain interface {
 	// cleanup any resources that won't be cleaned up by container and test file teardown
 	// for example if containers use a different user, and need the files to be deleted inside the container
 	Cleanup(ctx context.Context) error
+
+	// RegisterInterchainAccount will register an interchain account on behalf of the calling chain (controller chain)
+	// on the counterparty chain (the host chain).
+	RegisterInterchainAccount(ctx context.Context, keyName, connectionID string) (string, error)
+
+	// SendICABankTransfer will send a bank transfer msg from the fromAddr to the specified address for the given amount and denom.
+	SendICABankTransfer(ctx context.Context, connectionID, fromAddr string, amount WalletAmount) error
+
+	// QueryInterchainAccount will query the interchain account that was created on behalf of the specified address.
+	QueryInterchainAccount(ctx context.Context, connectionID, address string) (string, error)
 }

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -1,5 +1,7 @@
 package ibc
 
+import ibcexported "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
+
 type ChainConfig struct {
 	Type           string
 	Name           string
@@ -53,6 +55,18 @@ type ChannelOutput struct {
 	PortID         string              `json:"port_id"`
 	ChannelID      string              `json:"channel_id"`
 }
+
+// ConnectionOutput represents the IBC connection information queried from a chain's state for a particular connection.
+type ConnectionOutput struct {
+	ID           string                    `json:"id,omitempty" yaml:"id"`
+	ClientID     string                    `json:"client_id,omitempty" yaml:"client_id"`
+	Versions     []*ibcexported.Version    `json:"versions,omitempty" yaml:"versions"`
+	State        string                    `json:"state,omitempty" yaml:"state"`
+	Counterparty *ibcexported.Counterparty `json:"counterparty" yaml:"counterparty"`
+	DelayPeriod  string                    `json:"delay_period,omitempty" yaml:"delay_period"`
+}
+
+type ConnectionOutputs []*ConnectionOutput
 
 type RelayerWallet struct {
 	Mnemonic string `json:"mnemonic"`

--- a/test_chains.go
+++ b/test_chains.go
@@ -17,6 +17,7 @@ var chainConfigs = []ibc.ChainConfig{
 	cosmos.NewCosmosHeighlinerChainConfig("osmosis", "osmosisd", "osmo", "uosmo", "0.0uosmo", 1.3, "336h", false),
 	cosmos.NewCosmosHeighlinerChainConfig("juno", "junod", "juno", "ujuno", "0.0025ujuno", 1.3, "672h", false),
 	cosmos.NewCosmosHeighlinerChainConfig("agoric", "agd", "agoric", "urun", "0.01urun", 1.3, "672h", true),
+	cosmos.NewCosmosHeighlinerChainConfig("icad", "icad", "cosmos", "photon", "0.00photon", 1.2, "504h", false),
 	penumbra.NewPenumbraChainConfig(),
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR adds the necessary types and functionality that should be required to support testing interchain accounts.
This PR *does not* add testing scenarios that simulate the usage of interchain accounts.

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project

## Changes

Added methods to the `Chain` interface for registering an interchain account, querying an interchain account, and sending a bank transfer message to an interchain account.

Added methods for creating clients, creating connections, and querying connections to the `Relayer` interface.

Added a test chain that will utilize a docker image for the binary from the interchain accounts [demo](https://github.com/cosmos/interchain-accounts-demo)

Removed newline from end of error message.

