### PR TITLE
fix: More descriptive polling errors

### DIFF
--- a/conformance/test.go
+++ b/conformance/test.go
@@ -49,7 +49,7 @@ import (
 const (
 	userFaucetFund = int64(10_000_000_000)
 	testCoinAmount = int64(1_000_000)
-	pollHeightMax  = uint64(100)
+	pollHeightMax  = uint64(50)
 )
 
 type RelayerTestCase struct {

--- a/test/poll_for_state.go
+++ b/test/poll_for_state.go
@@ -143,6 +143,7 @@ func (pe *pollError) Unwrap() error {
 	return pe.error
 }
 
+// Format is expected to be used by testify/require which prints errors via %+v
 func (pe *pollError) Format(s fmt.State, verb rune) {
 	if verb != 'v' && !s.Flag('+') {
 		fmt.Fprint(s, pe.error.Error())

--- a/test/poll_for_state.go
+++ b/test/poll_for_state.go
@@ -137,7 +137,7 @@ func (pe *pollError) Error() string {
 		searched = "(none)"
 	}
 	target := spew.Sdump(pe.targetPacket)
-	return fmt.Sprintf("error: %s\n- target packet: %s\n- searched:\n%+v", pe.error, target, searched)
+	return fmt.Sprintf("%s\n- target packet:\n%s\n- searched:\n%+v", pe.error, target, searched)
 }
 func (pe *pollError) SetErr(err error) {
 	pe.error = err

--- a/test/poll_for_state.go
+++ b/test/poll_for_state.go
@@ -102,7 +102,7 @@ func (p blockPoller) findAck(ctx context.Context, height uint64, packet ibc.Pack
 		return zero, err
 	}
 	for _, ack := range acks {
-		p.pollErr.pushSearched(ack)
+		p.pollErr.PushSearched(ack)
 		if ack.Packet.Equal(packet) {
 			return ack, nil
 		}
@@ -117,7 +117,7 @@ func (p blockPoller) findTimeout(ctx context.Context, height uint64, packet ibc.
 		return zero, err
 	}
 	for _, t := range timeouts {
-		p.pollErr.pushSearched(t)
+		p.pollErr.PushSearched(t)
 		if t.Packet.Equal(packet) {
 			return t, nil
 		}
@@ -135,7 +135,7 @@ func (pe *pollError) SetErr(err error) {
 	pe.error = err
 }
 
-func (pe *pollError) pushSearched(packet interface{}) {
+func (pe *pollError) PushSearched(packet interface{}) {
 	pe.searchedPackets = append(pe.searchedPackets, spew.Sdump(packet))
 }
 

--- a/test/poll_for_state.go
+++ b/test/poll_for_state.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/strangelove-ventures/ibctest/ibc"
 )
 
@@ -58,9 +59,9 @@ func (p blockPoller) doPoll(ctx context.Context, startHeight, maxHeight uint64, 
 	if maxHeight < startHeight {
 		panic("maxHeight must be greater than or equal to startHeight")
 	}
-	p.pollErr = &pollError{}
-	cursor := startHeight
+	p.pollErr = &pollError{targetPacket: packet}
 
+	cursor := startHeight
 	for cursor <= maxHeight {
 		curHeight, err := p.CurrentHeight(ctx)
 		if err != nil {
@@ -135,14 +136,15 @@ func (pe *pollError) Error() string {
 	if len(searched) == 0 {
 		searched = "(none)"
 	}
-	return fmt.Sprintf("error: %v\n- target packet: %+v\n- searched:\n%+v", pe.error, pe.targetPacket, searched)
+	target := spew.Sdump(pe.targetPacket)
+	return fmt.Sprintf("error: %s\n- target packet: %s\n- searched:\n%+v", pe.error, target, searched)
 }
 func (pe *pollError) SetErr(err error) {
 	pe.error = err
 }
 
 func (pe *pollError) pushSearched(packet interface{}) {
-	pe.searchedPackets = append(pe.searchedPackets, fmt.Sprintf("%+v", packet))
+	pe.searchedPackets = append(pe.searchedPackets, spew.Sdump(packet))
 }
 
 func (pe *pollError) Unwrap() error {

--- a/test/poll_for_state.go
+++ b/test/poll_for_state.go
@@ -3,6 +3,8 @@ package test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/strangelove-ventures/ibctest/ibc"
 )
@@ -49,17 +51,16 @@ type blockPoller struct {
 	CurrentHeight func(ctx context.Context) (uint64, error)
 	Acker         ChainAcker
 	Timeouter     ChainTimeouter
+	pollErr       *pollError
 }
 
 func (p blockPoller) doPoll(ctx context.Context, startHeight, maxHeight uint64, packet ibc.Packet) (interface{}, error) {
 	if maxHeight < startHeight {
 		panic("maxHeight must be greater than or equal to startHeight")
 	}
-	var (
-		cursor  = startHeight
-		findErr error
-		found   interface{}
-	)
+	p.pollErr = &pollError{}
+	cursor := startHeight
+
 	for cursor <= maxHeight {
 		curHeight, err := p.CurrentHeight(ctx)
 		if err != nil {
@@ -69,6 +70,10 @@ func (p blockPoller) doPoll(ctx context.Context, startHeight, maxHeight uint64, 
 			continue
 		}
 
+		var (
+			found   interface{}
+			findErr error
+		)
 		switch {
 		case p.Acker != nil:
 			found, findErr = p.findAck(ctx, cursor, packet)
@@ -79,13 +84,14 @@ func (p blockPoller) doPoll(ctx context.Context, startHeight, maxHeight uint64, 
 		}
 
 		if findErr != nil {
+			p.pollErr.SetErr(findErr)
 			cursor++
 			continue
 		}
 
 		return found, nil
 	}
-	return nil, findErr
+	return nil, p.pollErr
 }
 
 func (p blockPoller) findAck(ctx context.Context, height uint64, packet ibc.Packet) (ibc.PacketAcknowledgement, error) {
@@ -95,6 +101,7 @@ func (p blockPoller) findAck(ctx context.Context, height uint64, packet ibc.Pack
 		return zero, err
 	}
 	for _, ack := range acks {
+		p.pollErr.pushSearched(ack)
 		if ack.Packet.Equal(packet) {
 			return ack, nil
 		}
@@ -109,9 +116,35 @@ func (p blockPoller) findTimeout(ctx context.Context, height uint64, packet ibc.
 		return zero, err
 	}
 	for _, t := range timeouts {
+		p.pollErr.pushSearched(t)
 		if t.Packet.Equal(packet) {
 			return t, nil
 		}
 	}
 	return zero, ErrNotFound
+}
+
+type pollError struct {
+	error
+	targetPacket    ibc.Packet
+	searchedPackets []string
+}
+
+func (pe *pollError) Error() string {
+	searched := strings.Join(pe.searchedPackets, "\n")
+	if len(searched) == 0 {
+		searched = "(none)"
+	}
+	return fmt.Sprintf("error: %v\n- target packet: %+v\n- searched:\n%+v", pe.error, pe.targetPacket, searched)
+}
+func (pe *pollError) SetErr(err error) {
+	pe.error = err
+}
+
+func (pe *pollError) pushSearched(packet interface{}) {
+	pe.searchedPackets = append(pe.searchedPackets, fmt.Sprintf("%+v", packet))
+}
+
+func (pe *pollError) Unwrap() error {
+	return pe.error
 }

--- a/test/poll_for_state.go
+++ b/test/poll_for_state.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
@@ -146,7 +145,7 @@ func (pe *pollError) Unwrap() error {
 
 func (pe *pollError) Format(s fmt.State, verb rune) {
 	if verb != 'v' && !s.Flag('+') {
-		io.WriteString(s, pe.error.Error())
+		fmt.Fprint(s, pe.error.Error())
 		return
 	}
 
@@ -156,5 +155,5 @@ func (pe *pollError) Format(s fmt.State, verb rune) {
 	}
 	target := spew.Sdump(pe.targetPacket)
 	final := fmt.Sprintf("%s\n- target packet:\n%s\n- searched:\n%+v", pe.error, target, searched)
-	io.WriteString(s, final)
+	fmt.Fprint(s, final)
 }

--- a/test/poll_for_state_test.go
+++ b/test/poll_for_state_test.go
@@ -88,11 +88,11 @@ func TestPollForAck(t *testing.T) {
 		chain := mockChain{CurrentHeight: 1, FoundAcks: []ibc.PacketAcknowledgement{
 			{Packet: ibc.Packet{Sequence: 10}},
 		}}
-		_, err := PollForAck(ctx, &chain, 1, 3, ibc.Packet{Sequence: 1})
+		_, err := PollForAck(ctx, &chain, 1, 3, ibc.Packet{Sequence: 5})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not found")
-		require.Contains(t, err.Error(), "target packet: ")
+		require.Regexp(t, `target packet:.*Sequence.*5`, err.Error())
 		require.Contains(t, err.Error(), "searched:")
 		require.ErrorIs(t, err, ErrNotFound)
 		require.Equal(t, []uint64{1, 2, 3}, chain.GotHeights)

--- a/test/poll_for_state_test.go
+++ b/test/poll_for_state_test.go
@@ -92,7 +92,7 @@ func TestPollForAck(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not found")
-		require.Regexp(t, `target packet:.*Sequence.*5`, err.Error())
+		require.Regexp(t, `(?s)target packet:.*Sequence.*5`, err.Error())
 		require.Contains(t, err.Error(), "searched:")
 		require.ErrorIs(t, err, ErrNotFound)
 		require.Equal(t, []uint64{1, 2, 3}, chain.GotHeights)

--- a/test/poll_for_state_test.go
+++ b/test/poll_for_state_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/strangelove-ventures/ibctest/ibc"
@@ -91,11 +92,14 @@ func TestPollForAck(t *testing.T) {
 		_, err := PollForAck(ctx, &chain, 1, 3, ibc.Packet{Sequence: 5})
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "not found")
-		require.Regexp(t, `(?s)target packet:.*Sequence.*5`, err.Error())
-		require.Contains(t, err.Error(), "searched:")
+		require.EqualError(t, err, "not found")
 		require.ErrorIs(t, err, ErrNotFound)
 		require.Equal(t, []uint64{1, 2, 3}, chain.GotHeights)
+
+		longErr := fmt.Sprintf("%+v", err)
+		require.Contains(t, longErr, "not found")
+		require.Regexp(t, `(?s)target packet:.*Sequence.*5`, longErr)
+		require.Contains(t, longErr, "searched:")
 	})
 
 	t.Run("invalid args", func(t *testing.T) {


### PR DESCRIPTION
# Description, Motivation, and Context

"Not found" was an okay first pass. But for debugging, it's not super useful. The error message (although verbose) now inclues the error, the target packet, and all the resources searched for the target packet.

<img width="1069" alt="Screen Shot 2022-05-25 at 5 15 19 PM" src="https://user-images.githubusercontent.com/224251/170384529-3edd19e8-5908-487d-a0d4-d78b99c9223d.png">

## Known Limitations, Trade-offs, Tech Debt
* I think verbose error messages are ok (even preferred) for ibctest.