### PR TITLE
Add relayer setup conformance test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ ibctest orchestrates Go tests that utilize Docker containers for multiple
 You may focus on a specific tests using the `-test.run=<regex>` flag.
 
 ```shell
-ibctest -test.run=/<test category>/<chain combination>/<relayer>/<test name>
+ibctest -test.run=/<test category>/<chain combination>/<relayer>/<test subcategory>/<test name>
 ```
 
 If you want to focus on a specific test:
 
 ```shell
-ibctest -test.run=////relay_packet
-ibctest -test.run=////no_timeout
-ibctest -test.run=////height_timeout
-ibctest -test.run=////timestamp_timeout
+ibctest -test.run=/////relay_packet
+ibctest -test.run=/////no_timeout
+ibctest -test.run=/////height_timeout
+ibctest -test.run=/////timestamp_timeout
 ```
 
 Example of narrowing your focus even more:
@@ -32,7 +32,7 @@ ibctest -test.run=///rly/
 ibctest -test.run=//gaia/rly/
 
 # only run no_timeout test for Go relayer and gaia chains
-ibctest -test.run=//gaia/rly/no_timeout
+ibctest -test.run=//gaia/rly/conformance/no_timeout
 ```
 
 ## Contributing

--- a/conformance/relayersetup.go
+++ b/conformance/relayersetup.go
@@ -1,0 +1,104 @@
+package conformance
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/test"
+	"github.com/strangelove-ventures/ibctest/testreporter"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRelayerSetup contains a series of subtests that configure a relayer step-by-step.
+func TestRelayerSetup(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory, rep *testreporter.Reporter) {
+	rep.TrackTest(t)
+
+	home := t.TempDir()
+	pool, network := ibctest.DockerSetup(t)
+
+	req := require.New(rep.TestifyT(t))
+	chains, err := cf.Chains(t.Name())
+	req.NoError(err, "failed to get chains")
+
+	if len(chains) != 2 {
+		panic(fmt.Errorf("expected 2 chains, got %d", len(chains)))
+	}
+
+	c0, c1 := chains[0], chains[1]
+
+	r := rf.Build(t, pool, network, home)
+
+	const pathName = "p"
+	ic := ibctest.NewInterchain().
+		AddChain(c0).
+		AddChain(c1).
+		AddRelayer(r, "r").
+		AddLink(ibctest.InterchainLink{
+			// We are adding a link here so that the interchain object creates appropriate relayer wallets,
+			// but we call ic.Build with SkipPathCreation=true, so the link won't be created.
+			Chain1:  c0,
+			Chain2:  c1,
+			Relayer: r,
+
+			Path: pathName,
+		})
+
+	ctx := context.Background()
+	eRep := rep.RelayerExecReporter(t)
+
+	req.NoError(ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
+		TestName:  t.Name(),
+		HomeDir:   home,
+		Pool:      pool,
+		NetworkID: network,
+
+		// Create relayer keys and wallets but don't create links,
+		// since that is what we are about to test.
+		SkipPathCreation: true,
+	}))
+
+	// Now handle each creation step as a subtest in sequence.
+	// After each subtest, check t.Failed, which will be true if a subtest failed,
+	// to conditionally stop execution before the following subtest.
+
+	t.Run("generate path", func(t *testing.T) {
+		rep.TrackTest(t)
+		req := require.New(rep.TestifyT(t))
+
+		req.NoError(r.GeneratePath(ctx, rep.RelayerExecReporter(t), c0.Config().ChainID, c1.Config().ChainID, pathName))
+	})
+	if t.Failed() {
+		return
+	}
+
+	t.Run("create clients", func(t *testing.T) {
+		rep.TrackTest(t)
+		req := require.New(rep.TestifyT(t))
+
+		req.NoError(r.CreateClients(ctx, rep.RelayerExecReporter(t), pathName))
+	})
+	if t.Failed() {
+		return
+	}
+
+	// The client isn't created immediately -- wait for two blocks to ensure the clients are ready.
+	req.NoError(test.WaitForBlocks(ctx, 2, c0, c1))
+
+	t.Run("create connections", func(t *testing.T) {
+		rep.TrackTest(t)
+		req := require.New(rep.TestifyT(t))
+
+		req.NoError(r.CreateConnections(ctx, rep.RelayerExecReporter(t), pathName))
+	})
+	if t.Failed() {
+		return
+	}
+
+	t.Run("create channels", func(t *testing.T) {
+		rep.TrackTest(t)
+
+		rep.TrackSkip(t, "ibc.Relayer does not yet have a CreateChannels method")
+	})
+}

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -229,7 +229,12 @@ func Test(t *testing.T, cfs []ibctest.ChainFactory, rfs []ibctest.RelayerFactory
 								TestRelayerSetup(t, cf, rf, rep)
 							})
 
-							TestChainPair(t, cf, rf, rep)
+							t.Run("conformance", func(t *testing.T) {
+								rep.TrackTest(t)
+								rep.TrackParallel(t)
+
+								TestChainPair(t, cf, rf, rep)
+							})
 						})
 					}
 				})

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -222,6 +222,13 @@ func Test(t *testing.T, cfs []ibctest.ChainFactory, rfs []ibctest.RelayerFactory
 							rep.TrackParameters(t, rf.Labels(), cf.Labels())
 							rep.TrackParallel(t)
 
+							t.Run("relayer setup", func(t *testing.T) {
+								rep.TrackTest(t)
+								rep.TrackParallel(t)
+
+								TestRelayerSetup(t, cf, rf, rep)
+							})
+
 							TestChainPair(t, cf, rf, rep)
 						})
 					}

--- a/interchain.go
+++ b/interchain.go
@@ -132,6 +132,11 @@ type InterchainBuildOptions struct {
 
 	Pool      *dockertest.Pool
 	NetworkID string
+
+	// If set, ic.Build does not create paths or links in the relayer,
+	// but it does still configure keys and wallets for declared relayer-chain links.
+	// This is useful for tests that need lower-level access to configuring relayers.
+	SkipPathCreation bool
 }
 
 // Build starts all the chains and configures the relayers associated with the Interchain.
@@ -170,9 +175,13 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 		return err
 	}
 
+	// Some tests may want to configure the relayer from a lower level,
+	// but still have wallets configured.
+	if opts.SkipPathCreation {
+		return nil
+	}
+
 	// For every relayer link, teach the relayer about the link and create the link.
-	// TODO: this could be skipped with an appropriate flag on InterchainBuildOptions,
-	// if a test wanted to exercise a relayer from a lower level than LinkPath.
 	for rp, chains := range ic.links {
 		c0 := chains[0]
 		c1 := chains[1]


### PR DESCRIPTION
The test is not yet complete because ibc.Relayer does not yet have a
CreateChannel method -- this was likely an oversight as all other tests
so far simply use CreateLink to create clients, connections, and
channels in one shot.

But this is another example of the Interchain type greatly simplifying
setup for a conformance test.