### PR TITLE
Add CreateChannels method to ibc.Relayer

### DIFF
--- a/ibc/Relayer.go
+++ b/ibc/Relayer.go
@@ -61,6 +61,9 @@ type Relayer interface {
 	// between the src and dst chains.
 	CreateConnections(ctx context.Context, rep RelayerExecReporter, pathName string) error
 
+	// CreateChannel creates a channel on the given path with the provided options.
+	CreateChannel(ctx context.Context, rep RelayerExecReporter, pathName string, opts CreateChannelOptions) error
+
 	// UseDockerNetwork reports whether the relayer is run in the same docker network as the other chains.
 	//
 	// If false, the relayer will connect to the localhost-exposed ports instead of the docker hosts.
@@ -68,6 +71,16 @@ type Relayer interface {
 	// Relayer implementations provided by the ibctest module will report true,
 	// but custom implementations may report false.
 	UseDockerNetwork() bool
+}
+
+// CreateChannelOptions contains the configuration for creating a channel.
+type CreateChannelOptions struct {
+	SourcePortName string
+	DestPortName   string
+
+	Order string
+
+	Version string
 }
 
 // ExecReporter is the interface of a narrow type returned by testreporter.RelayerExecReporter.

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -436,6 +436,19 @@ func (relayer *CosmosRelayer) AddKey(ctx context.Context, rep ibc.RelayerExecRep
 	return wallet, err
 }
 
+func (relayer *CosmosRelayer) CreateChannel(ctx context.Context, rep ibc.RelayerExecReporter, pathName string, opts ibc.CreateChannelOptions) error {
+	command := []string{
+		"rly", "tx", "channel", pathName,
+		"--src-port", opts.SourcePortName,
+		"--dst-port", opts.DestPortName,
+		"--order", opts.Order,
+		"--version", opts.Version,
+
+		"--home", relayer.NodeHome(),
+	}
+	return dockerutil.HandleNodeJobError(relayer.NodeJob(ctx, rep, command))
+}
+
 // Dir is the directory where the test node files are stored
 func (relayer *CosmosRelayer) Dir() string {
 	return fmt.Sprintf("%s/%s/", relayer.home, relayer.Name())


### PR DESCRIPTION
This was one missing piece in the relayer setup conformance test.