### PR TITLE
DockerRelayer options

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -49,7 +49,7 @@ type ChainNode struct {
 	Client       rpcclient.Client
 	Container    *docker.Container
 	TestName     string
-	Image        ibc.ChainDockerImage
+	Image        ibc.DockerImage
 
 	lock sync.Mutex
 	log  *zap.Logger

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -58,7 +58,7 @@ func NewCosmosHeighlinerChainConfig(name string,
 		GasAdjustment:  gasAdjustment,
 		TrustingPeriod: trustingPeriod,
 		NoHostMount:    noHostMount,
-		Images: []ibc.ChainDockerImage{
+		Images: []ibc.DockerImage{
 			{
 				Repository: fmt.Sprintf("ghcr.io/strangelove-ventures/heighliner/%s", name),
 			},

--- a/chain/internal/tendermint/tendermint_node.go
+++ b/chain/internal/tendermint/tendermint_node.go
@@ -34,7 +34,7 @@ type TendermintNode struct {
 	Client    rpcclient.Client
 	Container *docker.Container
 	TestName  string
-	Image     ibc.ChainDockerImage
+	Image     ibc.DockerImage
 }
 
 // TendermintNodes is a collection of TendermintNode

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -26,7 +26,7 @@ type PenumbraAppNode struct {
 	NetworkID string
 	Pool      *dockertest.Pool
 	Container *docker.Container
-	Image     ibc.ChainDockerImage
+	Image     ibc.DockerImage
 }
 
 const (

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -64,7 +64,7 @@ func NewPenumbraChainConfig() ibc.ChainConfig {
 		GasPrices:      "0.0upenumbra",
 		GasAdjustment:  1.3,
 		TrustingPeriod: "672h",
-		Images: []ibc.ChainDockerImage{
+		Images: []ibc.DockerImage{
 			{
 				Repository: "ghcr.io/strangelove-ventures/heighliner/tendermint",
 			},

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -6,7 +6,7 @@ type ChainConfig struct {
 	Type           string
 	Name           string
 	ChainID        string
-	Images         []ChainDockerImage
+	Images         []DockerImage
 	Bin            string
 	Bech32Prefix   string
 	Denom          string
@@ -16,7 +16,7 @@ type ChainConfig struct {
 	NoHostMount    bool
 }
 
-type ChainDockerImage struct {
+type DockerImage struct {
 	Repository string
 	Version    string
 }

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -68,7 +68,10 @@ func NewDockerRelayer(log *zap.Logger, testName, home string, pool *dockertest.P
 		}
 	}
 
-	relayer.pullContainerImageIfNecessary(relayer.containerImage())
+	containerImage := relayer.containerImage()
+	if err := relayer.pullContainerImageIfNecessary(containerImage); err != nil {
+		log.Error("Error pulling container image", zap.String("repository", containerImage.Repository), zap.String("version", containerImage.Version), zap.Error(err))
+	}
 
 	return &relayer
 }

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -31,6 +31,9 @@ type DockerRelayer struct {
 
 	testName string
 
+	customImage *ibc.DockerImage
+	pullImage   bool
+
 	// The container created by StartRelayer.
 	container *docker.Container
 
@@ -40,8 +43,8 @@ type DockerRelayer struct {
 var _ ibc.Relayer = (*DockerRelayer)(nil)
 
 // NewDockerRelayer returns a new DockerRelayer.
-func NewDockerRelayer(log *zap.Logger, testName, home string, pool *dockertest.Pool, networkID string, c RelayerCommander) *DockerRelayer {
-	return &DockerRelayer{
+func NewDockerRelayer(log *zap.Logger, testName, home string, pool *dockertest.Pool, networkID string, c RelayerCommander, options ...RelayerOption) *DockerRelayer {
+	relayer := DockerRelayer{
 		log: log,
 
 		c: c,
@@ -50,8 +53,24 @@ func NewDockerRelayer(log *zap.Logger, testName, home string, pool *dockertest.P
 		pool:      pool,
 		networkID: networkID,
 
+		// pull true by default, can be overridden with options
+		pullImage: true,
+
 		testName: testName,
 	}
+
+	for _, opt := range options {
+		switch typedOpt := opt.(type) {
+		case RelayerOptionDockerImage:
+			relayer.customImage = &typedOpt.DockerImage
+		case RelayerOptionImagePull:
+			relayer.pullImage = typedOpt.Pull
+		}
+	}
+
+	relayer.pullContainerImageIfNecessary(relayer.containerImage())
+
+	return &relayer
 }
 
 func (r *DockerRelayer) AddChainConfiguration(ctx context.Context, rep ibc.RelayerExecReporter, chainConfig ibc.ChainConfig, keyName, rpcAddr, grpcAddr string) error {
@@ -204,14 +223,28 @@ func (r *DockerRelayer) StopRelayer(ctx context.Context, rep ibc.RelayerExecRepo
 	return r.pool.Client.RemoveContainer(docker.RemoveContainerOptions{ID: r.container.ID})
 }
 
-func (r *DockerRelayer) createNodeContainer(pathName string) error {
-	err := r.pool.Client.PullImage(docker.PullImageOptions{
-		Repository: r.c.ContainerImage(),
-		Tag:        r.c.ContainerVersion(),
-	}, docker.AuthConfiguration{})
-	if err != nil {
-		return err
+func (r *DockerRelayer) containerImage() (res ibc.DockerImage) {
+	if r.customImage != nil {
+		return *r.customImage
 	}
+	return ibc.DockerImage{
+		Repository: r.c.DefaultContainerImage(),
+		Version:    r.c.DefaultContainerVersion(),
+	}
+}
+
+func (r *DockerRelayer) pullContainerImageIfNecessary(containerImage ibc.DockerImage) error {
+	if !r.pullImage {
+		return nil
+	}
+	return r.pool.Client.PullImage(docker.PullImageOptions{
+		Repository: containerImage.Repository,
+		Tag:        containerImage.Version,
+	}, docker.AuthConfiguration{})
+}
+
+func (r *DockerRelayer) createNodeContainer(pathName string) error {
+	containerImage := r.containerImage()
 	containerName := fmt.Sprintf("%s-%s", r.c.Name(), pathName)
 	cmd := r.c.StartRelayer(pathName, r.NodeHome())
 	r.log.Info(
@@ -226,7 +259,7 @@ func (r *DockerRelayer) createNodeContainer(pathName string) error {
 			Cmd:        cmd,
 			Entrypoint: []string{},
 			Hostname:   r.HostName(pathName),
-			Image:      fmt.Sprintf("%s:%s", r.c.ContainerImage(), r.c.ContainerVersion()),
+			Image:      fmt.Sprintf("%s:%s", containerImage.Repository, containerImage.Version),
 			Labels:     map[string]string{"ibc-test": r.testName},
 		},
 		NetworkingConfig: &docker.NetworkingConfig{
@@ -263,14 +296,7 @@ func (r *DockerRelayer) NodeJob(ctx context.Context, rep ibc.RelayerExecReporter
 			err,
 		)
 	}()
-
-	err = r.pool.Client.PullImage(docker.PullImageOptions{
-		Repository: r.c.ContainerImage(),
-		Tag:        r.c.ContainerVersion(),
-	}, docker.AuthConfiguration{})
-	if err != nil {
-		return 1, "", "", err
-	}
+	containerImage := r.containerImage()
 	counter, _, _, _ := runtime.Caller(1)
 	caller := runtime.FuncForPC(counter).Name()
 	funcName := strings.Split(caller, ".")
@@ -288,7 +314,7 @@ func (r *DockerRelayer) NodeJob(ctx context.Context, rep ibc.RelayerExecReporter
 			User: dockerutil.GetDockerUserString(),
 			// random hostname is fine here, just for setup
 			Hostname:   dockerutil.CondenseHostName(container),
-			Image:      r.c.ContainerImage() + ":" + r.c.ContainerVersion(),
+			Image:      containerImage.Repository + ":" + containerImage.Version,
 			Cmd:        cmd,
 			Entrypoint: []string{},
 			Labels:     map[string]string{"ibc-test": r.testName},
@@ -366,8 +392,8 @@ type RelayerCommander interface {
 	// Name is the name of the relayer, e.g. "rly" or "hermes".
 	Name() string
 
-	ContainerImage() string
-	ContainerVersion() string
+	DefaultContainerImage() string
+	DefaultContainerVersion() string
 
 	// ConfigContent generates the content of the config file that will be passed to AddChainConfiguration.
 	ConfigContent(ctx context.Context, cfg ibc.ChainConfig, keyName, rpcAddr, grpcAddr string) ([]byte, error)

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -226,7 +226,7 @@ func (r *DockerRelayer) StopRelayer(ctx context.Context, rep ibc.RelayerExecRepo
 	return r.pool.Client.RemoveContainer(docker.RemoveContainerOptions{ID: r.container.ID})
 }
 
-func (r *DockerRelayer) containerImage() (res ibc.DockerImage) {
+func (r *DockerRelayer) containerImage() ibc.DockerImage {
 	if r.customImage != nil {
 		return *r.customImage
 	}

--- a/relayer/options.go
+++ b/relayer/options.go
@@ -1,0 +1,31 @@
+package relayer
+
+import (
+	"github.com/strangelove-ventures/ibctest/ibc"
+)
+
+type RelayerOption interface{}
+type RelayerOptions []RelayerOption
+
+type RelayerOptionDockerImage struct {
+	DockerImage ibc.DockerImage
+}
+
+func CustomDockerImage(repository string, version string) RelayerOption {
+	return RelayerOptionDockerImage{
+		DockerImage: ibc.DockerImage{
+			Repository: repository,
+			Version:    version,
+		},
+	}
+}
+
+type RelayerOptionImagePull struct {
+	Pull bool
+}
+
+func ImagePull(pull bool) RelayerOption {
+	return RelayerOptionImagePull{
+		Pull: pull,
+	}
+}

--- a/relayer/options.go
+++ b/relayer/options.go
@@ -4,7 +4,12 @@ import (
 	"github.com/strangelove-ventures/ibctest/ibc"
 )
 
-type RelayerOption interface{}
+// RelayerOption is used to customize the relayer configuration, whether constructed with the
+// RelayerFactory or with the more specific NewDockerRelayer or NewCosmosRelayer methods.
+type RelayerOption interface {
+	// relayerOption is a no-op to be more restrictive on what types can be used as RelayerOptions
+	relayerOption()
+}
 type RelayerOptions []RelayerOption
 
 type RelayerOptionDockerImage struct {
@@ -20,6 +25,8 @@ func CustomDockerImage(repository string, version string) RelayerOption {
 	}
 }
 
+func (opt RelayerOptionDockerImage) relayerOption() {}
+
 type RelayerOptionImagePull struct {
 	Pull bool
 }
@@ -29,3 +36,5 @@ func ImagePull(pull bool) RelayerOption {
 		Pull: pull,
 	}
 }
+
+func (opt RelayerOptionImagePull) relayerOption() {}

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -21,10 +21,10 @@ type CosmosRelayer struct {
 	*relayer.DockerRelayer
 }
 
-func NewCosmosRelayer(log *zap.Logger, testName, home string, pool *dockertest.Pool, networkID string) *CosmosRelayer {
+func NewCosmosRelayer(log *zap.Logger, testName, home string, pool *dockertest.Pool, networkID string, options ...relayer.RelayerOption) *CosmosRelayer {
 	c := commander{log: log}
 	r := &CosmosRelayer{
-		DockerRelayer: relayer.NewDockerRelayer(log, testName, home, pool, networkID, c),
+		DockerRelayer: relayer.NewDockerRelayer(log, testName, home, pool, networkID, c, options),
 	}
 
 	if err := os.MkdirAll(r.Dir(), 0755); err != nil {
@@ -55,8 +55,8 @@ type CosmosRelayerChainConfig struct {
 }
 
 const (
-	ContainerImage   = "ghcr.io/cosmos/relayer"
-	ContainerVersion = "v2.0.0-beta4"
+	DefaultContainerImage   = "ghcr.io/cosmos/relayer"
+	DefaultContainerVersion = "v2.0.0-beta4"
 )
 
 // Capabilities returns the set of capabilities of the Cosmos relayer.
@@ -203,12 +203,12 @@ func (commander) ConfigContent(ctx context.Context, cfg ibc.ChainConfig, keyName
 	return jsonBytes, nil
 }
 
-func (commander) ContainerImage() string {
-	return ContainerImage
+func (commander) DefaultContainerImage() string {
+	return DefaultContainerImage
 }
 
-func (commander) ContainerVersion() string {
-	return ContainerVersion
+func (commander) DefaultContainerVersion() string {
+	return DefaultContainerVersion
 }
 
 func (commander) ParseAddKeyOutput(stdout, stderr string) (ibc.RelayerWallet, error) {

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -24,7 +24,7 @@ type CosmosRelayer struct {
 func NewCosmosRelayer(log *zap.Logger, testName, home string, pool *dockertest.Pool, networkID string, options ...relayer.RelayerOption) *CosmosRelayer {
 	c := commander{log: log}
 	r := &CosmosRelayer{
-		DockerRelayer: relayer.NewDockerRelayer(log, testName, home, pool, networkID, c, options),
+		DockerRelayer: relayer.NewDockerRelayer(log, testName, home, pool, networkID, c, options...),
 	}
 
 	if err := os.MkdirAll(r.Dir(), 0755); err != nil {

--- a/relayerfactory.go
+++ b/relayerfactory.go
@@ -66,7 +66,7 @@ func (f builtinRelayerFactory) Build(
 			home,
 			pool,
 			networkID,
-			f.options,
+			f.options...,
 		)
 	default:
 		panic(fmt.Errorf("RelayerImplementation %v unknown", f.impl))


### PR DESCRIPTION
Renames `ibc.ChainDockerImage` to `ibc.DockerImage` since it can also apply to the relayer.

Adds options to customize `DockerRelayer`:

- `RelayerOptionDockerImage` to use a custom docker image
- `RelayerOptionImagePull` to optionally disable image pull (helpful for local relayer images)