### PR TITLE
feat: Keep track of git commit in sqlite in a schema_version table

### DIFF
--- a/chainset.go
+++ b/chainset.go
@@ -121,7 +121,7 @@ func (cs chainSet) TrackBlocks(ctx context.Context, testName, dbPath, gitSha str
 		return fmt.Errorf("connect to sqlite database %s: %w", dbPath, err)
 	}
 
-	if err := blockdb.Migrate(db); err != nil {
+	if err := blockdb.Migrate(db, gitSha); err != nil {
 		return fmt.Errorf("migrate sqlite database %s; deleting file recommended: %w", dbPath, err)
 	}
 

--- a/internal/blockdb/chain.go
+++ b/internal/blockdb/chain.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
-	"time"
 
 	"golang.org/x/sync/singleflight"
 )
@@ -65,8 +64,7 @@ func (chain *Chain) saveBlock(ctx context.Context, height uint64, txs transactio
 	}
 	defer func() { _ = dbTx.Rollback() }()
 
-	now := time.Now().UTC().Format(time.RFC3339)
-	res, err := dbTx.ExecContext(ctx, `INSERT OR REPLACE INTO block(height, fk_chain_id, created_at) VALUES (?, ?, ?)`, height, chain.id, now)
+	res, err := dbTx.ExecContext(ctx, `INSERT OR REPLACE INTO block(height, fk_chain_id, created_at) VALUES (?, ?, ?)`, height, chain.id, nowRFC3339())
 	if err != nil {
 		return fmt.Errorf("insert into block: %w", err)
 	}

--- a/internal/blockdb/migrate_test.go
+++ b/internal/blockdb/migrate_test.go
@@ -26,6 +26,8 @@ func TestMigrate(t *testing.T) {
 	require.Equal(t, 1, count)
 
 	err = Migrate(db, "new-sha")
+	require.NoError(t, err)
+
 	row = db.QueryRow(`select count(*) from schema_version`)
 	err = row.Scan(&count)
 

--- a/internal/blockdb/migrate_test.go
+++ b/internal/blockdb/migrate_test.go
@@ -10,6 +10,32 @@ func TestMigrate(t *testing.T) {
 	db := emptyDB()
 	defer db.Close()
 
-	err := Migrate(db)
+	const gitSha = "abc123"
+	err := Migrate(db, gitSha)
 	require.NoError(t, err)
+
+	// idempotent
+	err = Migrate(db, gitSha)
+	require.NoError(t, err)
+
+	row := db.QueryRow(`select count(*) from schema_version`)
+	var count int
+	err = row.Scan(&count)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	err = Migrate(db, "new-sha")
+	row = db.QueryRow(`select count(*) from schema_version`)
+	err = row.Scan(&count)
+
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+
+	row = db.QueryRow(`select git_sha from schema_version order by id desc limit 1`)
+	var gotSha string
+	err = row.Scan(&gotSha)
+
+	require.NoError(t, err)
+	require.Equal(t, "new-sha", gotSha)
 }

--- a/internal/blockdb/sql.go
+++ b/internal/blockdb/sql.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -33,4 +34,8 @@ func ConnectDB(ctx context.Context, databasePath string) (*sql.DB, error) {
 		return nil, fmt.Errorf("ping db %s: %w", databasePath, err)
 	}
 	return db, err
+}
+
+func nowRFC3339() string {
+	return time.Now().UTC().Format(time.RFC3339)
 }

--- a/internal/blockdb/sql_test.go
+++ b/internal/blockdb/sql_test.go
@@ -21,7 +21,7 @@ func emptyDB() *sql.DB {
 
 func migratedDB() *sql.DB {
 	db := emptyDB()
-	if err := Migrate(db); err != nil {
+	if err := Migrate(db, "test"); err != nil {
 		panic(err)
 	}
 	return db

--- a/internal/blockdb/test_case.go
+++ b/internal/blockdb/test_case.go
@@ -3,7 +3,6 @@ package blockdb
 import (
 	"context"
 	"database/sql"
-	"time"
 )
 
 // TestCase is a single test invocation.
@@ -14,8 +13,7 @@ type TestCase struct {
 
 // CreateTestCase starts tracking new test case with testName.
 func CreateTestCase(ctx context.Context, db *sql.DB, testName, gitSha string) (*TestCase, error) {
-	now := time.Now().UTC().Format(time.RFC3339)
-	res, err := db.ExecContext(ctx, `INSERT INTO test_case(name, created_at, git_sha) VALUES(?, ?, ?)`, testName, now, gitSha)
+	res, err := db.ExecContext(ctx, `INSERT INTO test_case(name, created_at, git_sha) VALUES(?, ?, ?)`, testName, nowRFC3339(), gitSha)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description, Motivation, and Context

Solves the problem if someone sends us a db file, we'll be able to know which version of ibctest produced that file. 

## Known Limitations, Trade-offs, Tech Debt
* Git sha is also captured in `test_case` table but this is more explicit. 