### PR TITLE
Enforce chain name uniqueness on Interchain

### DIFF
--- a/chainfactory.go
+++ b/chainfactory.go
@@ -44,7 +44,18 @@ type BuiltinChainFactory struct {
 
 // BuiltinChainFactoryEntry describes a chain to be returned from an instance of BuiltinChainFactory.
 type BuiltinChainFactoryEntry struct {
-	Name          string
+	// Name refers to the keys in builtinChainConfigs.
+	// If the Name does not reference an existing chain config,
+	// retrieving the chain will result in an error
+	// including details of the available builtin names.
+	Name string
+
+	// Interchain structs require each chain name to be unique.
+	// In normal use this is not an issue,
+	// but in some tests it can be desirable to have two independent instances of the same chain.
+	// Set the NameOverride (and the ChainID) to distinguish multiple instances.
+	NameOverride string
+
 	Version       string
 	ChainID       string
 	NumValidators int
@@ -64,6 +75,9 @@ func (e BuiltinChainFactoryEntry) GetChain(log *zap.Logger, testName string) (ib
 	}
 
 	chainConfig.ChainID = e.ChainID
+	if e.NameOverride != "" {
+		chainConfig.Name = e.NameOverride
+	}
 
 	switch chainConfig.Type {
 	case "cosmos":

--- a/interchain.go
+++ b/interchain.go
@@ -56,7 +56,12 @@ type relayerPath struct {
 // If the given chain already exists,
 // or if another chain with the same configured chain ID exists, AddChain panics.
 func (ic *Interchain) AddChain(chain ibc.Chain) *Interchain {
+	if chain == nil {
+		panic(fmt.Errorf("cannot add nil chain"))
+	}
+
 	newID := chain.Config().ChainID
+	newName := chain.Config().Name
 
 	for c, id := range ic.chains {
 		if c == chain {
@@ -64,6 +69,9 @@ func (ic *Interchain) AddChain(chain ibc.Chain) *Interchain {
 		}
 		if id == newID {
 			panic(fmt.Errorf("a chain with ID %s already exists", id))
+		}
+		if c.Config().Name == newName {
+			panic(fmt.Errorf("a chain with name %s already exists", newName))
 		}
 	}
 
@@ -73,6 +81,10 @@ func (ic *Interchain) AddChain(chain ibc.Chain) *Interchain {
 
 // AddRelayer adds the given relayer with the given name to the Interchain.
 func (ic *Interchain) AddRelayer(relayer ibc.Relayer, name string) *Interchain {
+	if relayer == nil {
+		panic(fmt.Errorf("cannot add nil relayer"))
+	}
+
 	for r, n := range ic.relayers {
 		if r == relayer {
 			panic(fmt.Errorf("relayer %v was already added", r))

--- a/interchain_test.go
+++ b/interchain_test.go
@@ -2,12 +2,15 @@ package ibctest_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/strangelove-ventures/ibctest"
 	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/relayer/rly"
 	"github.com/strangelove-ventures/ibctest/testreporter"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -23,8 +26,8 @@ func TestInterchain_DuplicateChain(t *testing.T) {
 
 	cf := ibctest.NewBuiltinChainFactory([]ibctest.BuiltinChainFactoryEntry{
 		// Two otherwise identical chains that only differ by ChainID.
-		{Name: "gaia", Version: "v7.0.1", ChainID: "cosmoshub-0", NumValidators: 2, NumFullNodes: 1},
-		{Name: "gaia", Version: "v7.0.1", ChainID: "cosmoshub-1", NumValidators: 2, NumFullNodes: 1},
+		{Name: "gaia", NameOverride: "g1", Version: "v7.0.1", ChainID: "cosmoshub-0", NumValidators: 2, NumFullNodes: 1},
+		{Name: "gaia", NameOverride: "g2", Version: "v7.0.1", ChainID: "cosmoshub-1", NumValidators: 2, NumFullNodes: 1},
 	}, zaptest.NewLogger(t))
 
 	chains, err := cf.Chains(t.Name())
@@ -58,4 +61,78 @@ func TestInterchain_DuplicateChain(t *testing.T) {
 
 		SkipPathCreation: true,
 	}))
+}
+
+func TestInterchain_ConflictRejection(t *testing.T) {
+	t.Run("duplicate chain", func(t *testing.T) {
+		cf := ibctest.NewBuiltinChainFactory([]ibctest.BuiltinChainFactoryEntry{
+			{Name: "gaia", Version: "v7.0.1", ChainID: "cosmoshub-0", NumValidators: 2, NumFullNodes: 1},
+		}, zap.NewNop())
+
+		chains, err := cf.Chains(t.Name())
+		require.NoError(t, err)
+		chain := chains[0]
+
+		exp := fmt.Sprintf("chain %v was already added", chain)
+		require.PanicsWithError(t, exp, func() {
+			_ = ibctest.NewInterchain().AddChain(chain).AddChain(chain)
+		})
+	})
+
+	t.Run("chain name", func(t *testing.T) {
+		cf := ibctest.NewBuiltinChainFactory([]ibctest.BuiltinChainFactoryEntry{
+			// Different ChainID, but no NameOverride supplied.
+			{Name: "gaia", Version: "v7.0.1", ChainID: "cosmoshub-0", NumValidators: 2, NumFullNodes: 1},
+			{Name: "gaia", Version: "v7.0.1", ChainID: "cosmoshub-1", NumValidators: 2, NumFullNodes: 1},
+		}, zap.NewNop())
+
+		chains, err := cf.Chains(t.Name())
+		require.NoError(t, err)
+
+		require.PanicsWithError(t, "a chain with name gaia already exists", func() {
+			_ = ibctest.NewInterchain().AddChain(chains[0]).AddChain(chains[1])
+		})
+	})
+
+	t.Run("chain ID", func(t *testing.T) {
+		cf := ibctest.NewBuiltinChainFactory([]ibctest.BuiltinChainFactoryEntry{
+			// Valid NameOverride but duplicate ChainID.
+			{Name: "gaia", NameOverride: "g1", Version: "v7.0.1", ChainID: "cosmoshub-0", NumValidators: 2, NumFullNodes: 1},
+			{Name: "gaia", NameOverride: "g2", Version: "v7.0.1", ChainID: "cosmoshub-0", NumValidators: 2, NumFullNodes: 1},
+		}, zap.NewNop())
+
+		chains, err := cf.Chains(t.Name())
+		require.NoError(t, err)
+
+		require.PanicsWithError(t, "a chain with ID cosmoshub-0 already exists", func() {
+			_ = ibctest.NewInterchain().AddChain(chains[0]).AddChain(chains[1])
+		})
+	})
+
+	t.Run("duplicate relayer", func(t *testing.T) {
+		var r rly.CosmosRelayer
+
+		exp := fmt.Sprintf("relayer %v was already added", &r)
+		require.PanicsWithError(t, exp, func() {
+			_ = ibctest.NewInterchain().AddRelayer(&r, "r1").AddRelayer(&r, "r2")
+		})
+	})
+
+	t.Run("relayer name", func(t *testing.T) {
+		var r1, r2 rly.CosmosRelayer
+
+		require.PanicsWithError(t, "a relayer with name r already exists", func() {
+			_ = ibctest.NewInterchain().AddRelayer(&r1, "r").AddRelayer(&r2, "r")
+		})
+	})
+}
+
+func TestInterchain_AddNil(t *testing.T) {
+	require.PanicsWithError(t, "cannot add nil chain", func() {
+		_ = ibctest.NewInterchain().AddChain(nil)
+	})
+
+	require.PanicsWithError(t, "cannot add nil relayer", func() {
+		_ = ibctest.NewInterchain().AddRelayer(nil, "r")
+	})
 }


### PR DESCRIPTION
Also validate that AddChain and AddRelayer are not called with nil
values, and add tests to ensure the Add functions panic as intended upon
programmer error.

Closes #116.