### PR TITLE
fix: Sqlite errors on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,11 @@ jobs:
       #     docker rm -f $(docker ps -a -q) || true
       #     docker network prune -f || true
 
+      # cleanup environment on self-hosted test runner
+      - name: clean
+        run: -|
+          rm -f $HOME/.ibctest/databases/block.db
+
       # run tests
       - name: run all tests
         # show cosmos chain and relayer logs on test failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       # cleanup environment on self-hosted test runner
       - name: clean
         run: -|
-          rm -f $HOME/.ibctest/databases/block.db
+          rm -rf ~/.ibctest
 
       # run tests
       - name: run all tests

--- a/chainset.go
+++ b/chainset.go
@@ -148,7 +148,7 @@ func (cs chainSet) TrackBlocks(ctx context.Context, testName, dbPath, gitSha str
 		eg.Go(func() error {
 			chaindb, err := testCase.AddChain(ctx, id)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to chain %s to database: %v", id, err)
+				fmt.Fprintf(os.Stderr, "Failed to add chain %s to database: %v", id, err)
 				return nil
 			}
 			blockdb.NewCollector(zap.NewNop(), finder, chaindb, 100*time.Millisecond).Collect(ctx)


### PR DESCRIPTION
Addresses:

https://github.com/strangelove-ventures/ibctest/runs/6757520076?check_suite_focus=true#step:4:1058

> Failed to chain gaia-9 to database: SQL logic error: table chain has no column named chain_id (1)Failed to chain osmosis-10 to database: SQL logic error: table chain has no column named chain_id (1)=== RUN   TestConformance/chain_pairs/gaia-9@v7.0.1+osmosis-10@v7.2.0/rly@v2.0.0-beta4/relayer_setup/generate_path

In the context of a self-hosted test-runner, I feel cleaning up the environment before each test run is wise. Otherwise, something like this database will expand uncontrollably. 