### PR TITLE
Add test ensuring git sha can be omitted from interchain build options

### DIFF
--- a/chainset.go
+++ b/chainset.go
@@ -121,12 +121,12 @@ func (cs chainSet) TrackBlocks(ctx context.Context, testName, dbPath, gitSha str
 		return fmt.Errorf("connect to sqlite database %s: %w", dbPath, err)
 	}
 
-	if err := blockdb.Migrate(db, gitSha); err != nil {
-		return fmt.Errorf("migrate sqlite database %s; deleting file recommended: %w", dbPath, err)
-	}
-
 	if len(gitSha) == 0 {
 		gitSha = "unknown"
+	}
+
+	if err := blockdb.Migrate(db, gitSha); err != nil {
+		return fmt.Errorf("migrate sqlite database %s; deleting file recommended: %w", dbPath, err)
 	}
 
 	testCase, err := blockdb.CreateTestCase(ctx, db, testName, gitSha)


### PR DESCRIPTION
When importing the current version of ibctest into relayer, this error occurs if the BlockDatabaseFile field is provided but the GitSha is empty:

```
failed to track blocks: migrate sqlite database :memory:; deleting file recommended: upsert schema_version with git sha : constraint failed: CHECK constraint failed: length(git_sha) > 0 (275)
```

Default the git sha to `unknown` before attempting to add it to `schema_version` table, so that the GitSha is optional as documented.