### PR TITLE
Add tx_flattened view to blockdb

### DIFF
--- a/internal/blockdb/migrate.go
+++ b/internal/blockdb/migrate.go
@@ -80,5 +80,27 @@ ON CONFLICT(git_sha) DO UPDATE SET git_sha=git_sha`, nowRFC3339(), gitSha)
 		return fmt.Errorf("create table tx: %w", err)
 	}
 
+	_, err = db.Exec(`CREATE VIEW IF NOT EXISTS tx_flattened AS
+SELECT
+  test_case.id as test_case_id
+  , test_case.created_at as test_case_created_at
+  , test_case.name as test_case_name
+  , chain.id as chain_kid
+  , chain.chain_id as chain_id
+	, block.id as block_id
+  , block.created_at as block_created_at
+  , block.height as block_height
+  , tx.id as tx_id
+  , tx.data as tx
+ FROM tx
+ LEFT JOIN block ON tx.fk_block_id = block.id
+ LEFT JOIN chain ON block.fk_chain_id = chain.id
+ LEFT JOIN test_case ON chain.fk_test_id = test_case.id
+`)
+
+	if err != nil {
+		return fmt.Errorf("create tx_flattened view: %w", err)
+	}
+
 	return nil
 }

--- a/internal/blockdb/migrate.go
+++ b/internal/blockdb/migrate.go
@@ -80,7 +80,12 @@ ON CONFLICT(git_sha) DO UPDATE SET git_sha=git_sha`, nowRFC3339(), gitSha)
 		return fmt.Errorf("create table tx: %w", err)
 	}
 
-	_, err = db.Exec(`CREATE VIEW IF NOT EXISTS tx_flattened AS
+	_, err = db.Exec(`DROP VIEW IF EXISTS v_tx_flattened`)
+	if err != nil {
+		return fmt.Errorf("drop old v_tx_flattened view: %w", err)
+	}
+
+	_, err = db.Exec(`CREATE VIEW v_tx_flattened AS
 SELECT
   test_case.id as test_case_id
   , test_case.created_at as test_case_created_at
@@ -92,10 +97,10 @@ SELECT
   , block.height as block_height
   , tx.id as tx_id
   , tx.data as tx
- FROM tx
- LEFT JOIN block ON tx.fk_block_id = block.id
- LEFT JOIN chain ON block.fk_chain_id = chain.id
- LEFT JOIN test_case ON chain.fk_test_id = test_case.id
+FROM tx
+LEFT JOIN block ON tx.fk_block_id = block.id
+LEFT JOIN chain ON block.fk_chain_id = chain.id
+LEFT JOIN test_case ON chain.fk_test_id = test_case.id
 `)
 
 	if err != nil {

--- a/internal/blockdb/views_test.go
+++ b/internal/blockdb/views_test.go
@@ -1,0 +1,135 @@
+package blockdb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxFlattenedView(t *testing.T) {
+	t.Parallel()
+
+	db := migratedDB()
+	defer db.Close()
+
+	ctx := context.Background()
+
+	beforeTestCaseCreate := time.Now().UTC().Format(time.RFC3339)
+	tc, err := CreateTestCase(ctx, db, "mytest", "abc123")
+	require.NoError(t, err)
+
+	chain, err := tc.AddChain(ctx, "chain1")
+	require.NoError(t, err)
+
+	beforeBlocksCreated := time.Now().UTC().Format(time.RFC3339)
+	require.NoError(t, chain.SaveBlock(ctx, 1, [][]byte{
+		[]byte("tx1.0"),
+	}))
+	require.NoError(t, chain.SaveBlock(ctx, 2, [][]byte{
+		[]byte("tx2.0"),
+		[]byte("tx2.1"),
+	}))
+	afterBlocksCreated := time.Now().UTC().Format(time.RFC3339)
+
+	var (
+		tcID        int64
+		tcCreatedAt string
+		tcName      string
+
+		chainKeyID int64
+		chainID    string
+
+		blockID        int
+		blockCreatedAt string
+		blockHeight    int
+
+		txID int
+		tx   string
+	)
+	rows, err := db.Query(`SELECT
+  test_case_id, test_case_created_at, test_case_name,
+  chain_kid, chain_id,
+  block_id, block_created_at, block_height,
+  tx_id, tx
+FROM tx_flattened
+ORDER BY test_case_id, chain_kid, block_id, tx_id
+`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	// Collect the first row and make assertions.
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(
+		&tcID, &tcCreatedAt, &tcName,
+		&chainKeyID, &chainID,
+		&blockID, &blockCreatedAt, &blockHeight,
+		&txID, &tx,
+	))
+
+	require.Equal(t, tcID, tc.id)
+	require.GreaterOrEqual(t, tcCreatedAt, beforeTestCaseCreate)
+	require.LessOrEqual(t, tcCreatedAt, beforeBlocksCreated)
+	require.Equal(t, tcName, "mytest")
+
+	require.Equal(t, chainKeyID, chain.id)
+	require.Equal(t, chainID, "chain1")
+
+	require.GreaterOrEqual(t, blockCreatedAt, beforeBlocksCreated)
+	require.LessOrEqual(t, blockCreatedAt, afterBlocksCreated)
+	require.Equal(t, blockHeight, 1)
+
+	require.Equal(t, tx, "tx1.0")
+
+	// Save some state gathered from the first row.
+	firstBlockCreatedAt := blockCreatedAt
+	firstTxID := txID
+
+	// Collect the second row and make assertions.
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(
+		&tcID, &tcCreatedAt, &tcName,
+		&chainKeyID, &chainID,
+		&blockID, &blockCreatedAt, &blockHeight,
+		&txID, &tx,
+	))
+
+	// Same test case and chain.
+	require.Equal(t, tcID, tc.id)
+	require.Equal(t, chainKeyID, chain.id)
+
+	// New block height.
+	require.GreaterOrEqual(t, blockCreatedAt, firstBlockCreatedAt)
+	require.LessOrEqual(t, blockCreatedAt, afterBlocksCreated)
+	require.Equal(t, blockHeight, 2)
+
+	// Next transaction.
+	require.Greater(t, txID, firstTxID)
+	require.Equal(t, tx, "tx2.0")
+
+	secondTxID := txID
+
+	// Third and final row.
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(
+		&tcID, &tcCreatedAt, &tcName,
+		&chainKeyID, &chainID,
+		&blockID, &blockCreatedAt, &blockHeight,
+		&txID, &tx,
+	))
+
+	// Same test case and chain.
+	require.Equal(t, tcID, tc.id)
+	require.Equal(t, chainKeyID, chain.id)
+
+	// Same block height.
+	require.Equal(t, blockHeight, 2)
+
+	// Next transaction.
+	require.Greater(t, txID, secondTxID)
+	require.Equal(t, tx, "tx2.1")
+
+	// No more rows.
+	require.False(t, rows.Next())
+}

--- a/internal/blockdb/views_test.go
+++ b/internal/blockdb/views_test.go
@@ -53,7 +53,7 @@ func TestTxFlattenedView(t *testing.T) {
   chain_kid, chain_id,
   block_id, block_created_at, block_height,
   tx_id, tx
-FROM tx_flattened
+FROM v_tx_flattened
 ORDER BY test_case_id, chain_kid, block_id, tx_id
 `)
 	require.NoError(t, err)


### PR DESCRIPTION
This view materializes the transactions, joined with blocks, chains, and
test cases.

This is a helpful view for users who are directly interacting with the
sqlite database.

I intend to follow this up with another view that relies on this view,
and parses relevant client/connection/channel details from the tx
objects using sqlite's json functions.
