### PR TITLE
Add v_messages view to blockdb

### DIFF
--- a/internal/blockdb/messages_view_test.go
+++ b/internal/blockdb/messages_view_test.go
@@ -1,0 +1,297 @@
+package blockdb_test
+
+// This test is in a separate file, so it can be in the blockdb_test package,
+// so it can import ibctest without creating an import cycle.
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/test"
+	"github.com/strangelove-ventures/ibctest/testreporter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestMessagesView(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	t.Parallel()
+
+	home := t.TempDir()
+	pool, network := ibctest.DockerSetup(t)
+
+	const gaia0ChainID = "g0"
+	const gaia1ChainID = "g1"
+	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
+		{Name: "gaia", Version: "v7.0.1", ChainConfig: ibc.ChainConfig{ChainID: gaia0ChainID}},
+		{Name: "gaia", Version: "v7.0.1", ChainConfig: ibc.ChainConfig{ChainID: gaia1ChainID}},
+	})
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+
+	gaia0, gaia1 := chains[0], chains[1]
+
+	r := ibctest.NewBuiltinRelayerFactory(ibc.CosmosRly, zaptest.NewLogger(t)).Build(
+		t, pool, network, home,
+	)
+
+	ic := ibctest.NewInterchain().
+		AddChain(gaia0).
+		AddChain(gaia1).
+		AddRelayer(r, "r").
+		AddLink(ibctest.InterchainLink{
+			Chain1:  gaia0,
+			Chain2:  gaia1,
+			Relayer: r,
+		})
+
+	dbDir := t.TempDir()
+	dbPath := filepath.Join(dbDir, "blocks.db")
+
+	const debugging = true // TODO: remove before finalizing this change.
+	if debugging {
+		dbPath = "/tmp/blocks.db"
+		os.RemoveAll(dbPath)
+	}
+
+	rep := testreporter.NewNopReporter()
+	eRep := rep.RelayerExecReporter(t)
+
+	ctx := context.Background()
+	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
+		TestName:  t.Name(),
+		HomeDir:   home,
+		Pool:      pool,
+		NetworkID: network,
+
+		SkipPathCreation: true,
+
+		BlockDatabaseFile: dbPath,
+	}))
+
+	// The database should exist on disk,
+	// but no transactions should have happened yet.
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var count int
+	row := db.QueryRow(`SELECT COUNT(*) FROM v_messages`)
+	require.NoError(t, row.Scan(&count))
+	require.Equal(t, count, 0)
+
+	// Generate the path.
+	// No transactions happen here.
+	const pathName = "p"
+	require.NoError(t, r.GeneratePath(ctx, eRep, gaia0ChainID, gaia1ChainID, pathName))
+
+	t.Run("create clients", func(t *testing.T) {
+		// Creating the clients will cause transactions.
+		require.NoError(t, r.CreateClients(ctx, eRep, pathName))
+
+		// MsgCreateClient should match the opposite chain IDs.
+		const qCreateClient = `SELECT
+client_chain_id
+FROM v_messages
+WHERE type = "/ibc.core.client.v1.MsgCreateClient" AND chain_id = ?;`
+		var clientChainID string
+		require.NoError(t, db.QueryRow(qCreateClient, gaia0ChainID).Scan(&clientChainID))
+		require.Equal(t, clientChainID, gaia1ChainID)
+
+		require.NoError(t, db.QueryRow(qCreateClient, gaia1ChainID).Scan(&clientChainID))
+		require.Equal(t, clientChainID, gaia0ChainID)
+	})
+	if t.Failed() {
+		return
+	}
+
+	var gaia0ClientID, gaia0ConnID, gaia1ClientID, gaia1ConnID string
+	t.Run("create connections", func(t *testing.T) {
+		// The client isn't created immediately -- wait for two blocks to ensure the clients are ready.
+		require.NoError(t, test.WaitForBlocks(ctx, 2, gaia0, gaia1))
+
+		// Next, create the connections.
+		require.NoError(t, r.CreateConnections(ctx, eRep, pathName))
+		conns, err := r.GetConnections(ctx, eRep, gaia0ChainID)
+		require.NoError(t, err)
+
+		// Collect the reported client IDs.
+		gaia0ConnID = conns[0].ID
+		gaia0ClientID = conns[0].ClientID
+		gaia1ConnID = conns[0].Counterparty.ConnectionId
+		gaia1ClientID = conns[0].Counterparty.ClientId
+
+		// OpenInit happens on first chain.
+		const qConnectionOpenInit = `SELECT
+client_id, counterparty_client_id
+FROM v_messages
+WHERE type = "/ibc.core.connection.v1.MsgConnectionOpenInit" AND chain_id = ?
+`
+		var clientID, counterpartyClientID string
+		require.NoError(t, db.QueryRow(qConnectionOpenInit, gaia0ChainID).Scan(&clientID, &counterpartyClientID))
+		require.Equal(t, clientID, gaia0ClientID)
+		require.Equal(t, counterpartyClientID, gaia1ClientID)
+
+		// OpenTry happens on second chain.
+		const qConnectionOpenTry = `SELECT
+counterparty_client_id, counterparty_conn_id
+FROM v_messages
+WHERE type = "/ibc.core.connection.v1.MsgConnectionOpenTry" AND chain_id = ?
+`
+		var counterpartyConnID string
+		require.NoError(t, db.QueryRow(qConnectionOpenTry, gaia1ChainID).Scan(&counterpartyClientID, &counterpartyConnID))
+		require.Equal(t, counterpartyClientID, gaia0ClientID)
+		require.Equal(t, counterpartyConnID, gaia0ConnID)
+
+		// OpenAck happens on first chain again.
+		const qConnectionOpenAck = `SELECT
+conn_id, counterparty_conn_id
+FROM v_messages
+WHERE type = "/ibc.core.connection.v1.MsgConnectionOpenAck" AND chain_id = ?
+`
+		var connID string
+		require.NoError(t, db.QueryRow(qConnectionOpenAck, gaia0ChainID).Scan(&connID, &counterpartyConnID))
+		require.Equal(t, connID, gaia0ConnID)
+		require.Equal(t, counterpartyConnID, gaia1ConnID)
+
+		// OpenConfirm happens on second chain again.
+		const qConnectionOpenConfirm = `SELECT
+conn_id
+FROM v_messages
+WHERE type = "/ibc.core.connection.v1.MsgConnectionOpenConfirm" AND chain_id = ?
+`
+		require.NoError(t, db.QueryRow(qConnectionOpenConfirm, gaia1ChainID).Scan(&connID))
+		require.Equal(t, connID, gaia0ConnID) // Not sure if this should be connection 0 or 1, as they are typically equal during this test.
+	})
+	if t.Failed() {
+		return
+	}
+
+	const gaia0Port, gaia1Port = "transfer", "transfer" // Would be nice if these could differ.
+	var gaia0ChannelID, gaia1ChannelID string
+	t.Run("create channel", func(t *testing.T) {
+		require.NoError(t, r.CreateChannel(ctx, eRep, pathName, ibc.CreateChannelOptions{
+			SourcePortName: gaia0Port,
+			DestPortName:   gaia1Port,
+			Order:          "unordered",
+			Version:        "ics20-1",
+		}))
+
+		channels, err := r.GetChannels(ctx, eRep, gaia0ChainID)
+		require.NoError(t, err)
+		require.Len(t, channels, 1)
+
+		gaia0ChannelID = channels[0].ChannelID
+		gaia1ChannelID = channels[0].Counterparty.ChannelID
+
+		_ = gaia0ChannelID
+		_ = gaia1ChannelID
+
+		// OpenInit happens on first chain.
+		const qChannelOpenInit = `SELECT
+port_id, counterparty_port_id
+FROM v_messages
+WHERE type = "/ibc.core.channel.v1.MsgChannelOpenInit" AND chain_id = ?
+`
+		var portID, counterpartyPortID string
+		require.NoError(t, db.QueryRow(qChannelOpenInit, gaia0ChainID).Scan(&portID, &counterpartyPortID))
+		require.Equal(t, portID, gaia0Port)
+		require.Equal(t, counterpartyPortID, gaia1Port)
+
+		// OpenTry happens on second chain.
+		const qChannelOpenTry = `SELECT
+port_id, counterparty_port_id, counterparty_channel_id
+FROM v_messages
+WHERE type = "/ibc.core.channel.v1.MsgChannelOpenTry" AND chain_id = ?
+`
+		var counterpartyChannelID string
+		require.NoError(t, db.QueryRow(qChannelOpenTry, gaia1ChainID).Scan(&portID, &counterpartyPortID, &counterpartyChannelID))
+		require.Equal(t, portID, gaia1Port)
+		require.Equal(t, counterpartyPortID, gaia0Port)
+		require.Equal(t, counterpartyChannelID, gaia0ChannelID)
+
+		// OpenAck happens on first chain again.
+		const qChannelOpenAck = `SELECT
+port_id, channel_id, counterparty_channel_id
+FROM v_messages
+WHERE type = "/ibc.core.channel.v1.MsgChannelOpenAck" AND chain_id = ?
+`
+		var channelID string
+		require.NoError(t, db.QueryRow(qChannelOpenAck, gaia0ChainID).Scan(&portID, &channelID, &counterpartyChannelID))
+		require.Equal(t, portID, gaia0Port)
+		require.Equal(t, channelID, gaia0ChannelID)
+		require.Equal(t, counterpartyChannelID, gaia1ChannelID)
+
+		// OpenConfirm happens on second chain again.
+		const qChannelOpenConfirm = `SELECT
+port_id, channel_id
+FROM v_messages
+WHERE type = "/ibc.core.channel.v1.MsgChannelOpenConfirm" AND chain_id = ?
+`
+		require.NoError(t, db.QueryRow(qChannelOpenConfirm, gaia1ChainID).Scan(&portID, &channelID))
+		require.Equal(t, portID, gaia1Port)
+		require.Equal(t, channelID, gaia1ChannelID)
+	})
+	if t.Failed() {
+		return
+	}
+
+	t.Run("initiate transfer", func(t *testing.T) {
+		// Build the faucet address for gaia1, so that gaia0 can send it a transfer.
+		g1FaucetAddrBytes, err := gaia1.GetAddress(ctx, ibctest.FaucetAccountKeyName)
+		require.NoError(t, err)
+		gaia1FaucetAddr, err := types.Bech32ifyAddressBytes(gaia1.Config().Bech32Prefix, g1FaucetAddrBytes)
+		require.NoError(t, err)
+
+		// Send the IBC transfer. Relayer isn't running, so this will just create a MsgTransfer.
+		const txAmount = 13579 // Arbitrary amount that is easy to find in logs.
+		tx, err := gaia0.SendIBCTransfer(ctx, gaia0ChannelID, ibctest.FaucetAccountKeyName, ibc.WalletAmount{
+			Address: gaia1FaucetAddr,
+			Denom:   gaia0.Config().Denom,
+			Amount:  txAmount,
+		}, nil)
+		require.NoError(t, err)
+		require.NoError(t, tx.Validate())
+
+		const qMsgTransfer = `SELECT
+port_id, channel_id
+FROM v_messages
+WHERE type = "/ibc.applications.transfer.v1.MsgTransfer" AND chain_id = ?
+`
+		var portID, channelID string
+		require.NoError(t, db.QueryRow(qMsgTransfer, gaia0ChainID).Scan(&portID, &channelID))
+		require.Equal(t, portID, gaia0Port)
+		require.Equal(t, channelID, gaia0ChannelID)
+	})
+	if t.Failed() {
+		return
+	}
+
+	t.Run("relay packet", func(t *testing.T) {
+		require.NoError(t, r.ClearQueue(ctx, eRep, pathName, gaia0ChannelID))
+
+		const qMsgRecvPacket = `SELECT
+port_id, channel_id, counterparty_port_id, counterparty_channel_id
+FROM v_messages
+WHERE type = "/ibc.core.channel.v1.MsgRecvPacket" AND chain_id = ?
+`
+		var portID, channelID, counterpartyPortID, counterpartyChannelID string
+		require.NoError(t, db.QueryRow(qMsgRecvPacket, gaia1ChainID).Scan(&portID, &channelID, &counterpartyPortID, &counterpartyChannelID))
+
+		require.Equal(t, portID, gaia0Port)
+		require.Equal(t, channelID, gaia0ChannelID)
+	})
+
+	// TODO: relay acknowledgement.
+	// Blocked on ibc.Relayer.ClearQueue needing replaced with RelayPackets, RelayAcks.
+}


### PR DESCRIPTION
This adds a v_messages view to the sqlite database which gives an
overall view of the IBC messages being sent. This contains mostly full
data about client, connection, and channel handshakes; and limited
information about transfers.

There are two major next steps in this sequence:
1. Update the ibc.Relayer interface to separate the ClearQueue method
   into something like FlushPackets and FlushAcknowledgements.
2. Add a new view that gives more full detail about transfers; once the
   connections are configured, the transfers are far more interesting,
   but they also contain much more detail than the initial handshaking,
   so they aren't a great fit for the same view.

Of less importance than those two steps, we also need to decide where
information about MsgUpdateClient belongs, as currently it receives
almost no treatment in v_messages.

Should help with #123.