### PR TITLE
feat: Capture chain_type in sqlite chain table

### DIFF
--- a/chainset.go
+++ b/chainset.go
@@ -146,7 +146,7 @@ func (cs chainSet) TrackBlocks(ctx context.Context, testName, dbPath, gitSha str
 			return nil
 		}
 		eg.Go(func() error {
-			chaindb, err := testCase.AddChain(ctx, id)
+			chaindb, err := testCase.AddChain(ctx, id, c.Config().Type)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to add chain %s to database: %v", id, err)
 				return nil

--- a/internal/blockdb/chain_test.go
+++ b/internal/blockdb/chain_test.go
@@ -15,7 +15,7 @@ func validChain(t *testing.T, db *sql.DB) *Chain {
 
 	tc, err := CreateTestCase(context.Background(), db, "TestCase", "112233")
 	require.NoError(t, err)
-	c, err := tc.AddChain(context.Background(), "chain1")
+	c, err := tc.AddChain(context.Background(), "chain1", "cosmos")
 	require.NoError(t, err)
 	return c
 }

--- a/internal/blockdb/migrate.go
+++ b/internal/blockdb/migrate.go
@@ -110,7 +110,8 @@ SELECT
   , test_case.name as test_case_name
   , chain.id as chain_kid
   , chain.chain_id as chain_id
-	, block.id as block_id
+  , chain.chain_type as chain_type
+  , block.id as block_id
   , block.created_at as block_created_at
   , block.height as block_height
   , tx.id as tx_id

--- a/internal/blockdb/migrate.go
+++ b/internal/blockdb/migrate.go
@@ -20,6 +20,8 @@ import (
 //  │                    │          │                    │         │                    │          │                    │
 //  └────────────────────┘          └────────────────────┘         └────────────────────┘          └────────────────────┘
 // The gitSha ensures we can trace back to the version of the codebase that produced the schema.
+// Warning: Typical best practice wraps each migration step into its own transaction. For simplicity given
+// this is an embedded database, we omit transactions.
 func Migrate(db *sql.DB, gitSha string) error {
 	// TODO(nix 05-27-2022): Appropriate indexes?
 	_, err := db.Exec(`PRAGMA foreign_keys = ON`)

--- a/internal/blockdb/migrate.go
+++ b/internal/blockdb/migrate.go
@@ -84,7 +84,7 @@ ON CONFLICT(git_sha) DO UPDATE SET git_sha=git_sha`, nowRFC3339(), gitSha)
 		return fmt.Errorf("create table tx: %w", err)
 	}
 
-	_, err = db.Exec(`ALTER TABLE chain ADD COLUMN chain_type TEXT NOT NULL check(length(chain_type) > 0) DEFAULT "cosmos"`)
+	_, err = db.Exec(`ALTER TABLE chain ADD COLUMN chain_type TEXT NOT NULL check(length(chain_type) > 0) DEFAULT "unknown"`)
 	if errIgnoreDuplicateColumn(err, "chain_type") != nil {
 		return fmt.Errorf("alter table chain add chain_type: %w", err)
 	}

--- a/internal/blockdb/migrate.go
+++ b/internal/blockdb/migrate.go
@@ -2,7 +2,11 @@ package blockdb
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"strings"
+
+	"modernc.org/sqlite"
 )
 
 // Migrate migrates db in an idempotent manner.
@@ -80,7 +84,21 @@ ON CONFLICT(git_sha) DO UPDATE SET git_sha=git_sha`, nowRFC3339(), gitSha)
 		return fmt.Errorf("create table tx: %w", err)
 	}
 
-	_, err = db.Exec(`DROP VIEW IF EXISTS v_tx_flattened`)
+	_, err = db.Exec(`ALTER TABLE chain ADD COLUMN chain_type TEXT NOT NULL check(length(chain_type) > 0) DEFAULT "cosmos"`)
+	if errIgnoreDuplicateColumn(err, "chain_type") != nil {
+		return fmt.Errorf("alter table chain add chain_type: %w", err)
+	}
+
+	// Creating views should be last migration step.
+	// Error already wrapped.
+	return upsertViews(db)
+}
+
+// upsertViews should be idempotent by dropping/re-creating the view. The drop/re-create makes view authoring simpler
+// in case table columns are altered, added, or dropped.
+// Performance impact is negligible since views are essentially stored queries.
+func upsertViews(db *sql.DB) error {
+	_, err := db.Exec(`DROP VIEW IF EXISTS v_tx_flattened`)
 	if err != nil {
 		return fmt.Errorf("drop old v_tx_flattened view: %w", err)
 	}
@@ -158,4 +176,13 @@ FROM v_tx_flattened, json_each(v_tx_flattened.tx, "$.body.messages")
 	}
 
 	return nil
+}
+
+func errIgnoreDuplicateColumn(err error, col string) error {
+	var serr *sqlite.Error
+	if errors.As(err, &serr) &&
+		strings.Contains(serr.Error(), fmt.Sprintf("duplicate column name: %s", col)) {
+		return nil
+	}
+	return err
 }

--- a/internal/blockdb/migrate_test.go
+++ b/internal/blockdb/migrate_test.go
@@ -7,37 +7,51 @@ import (
 )
 
 func TestMigrate(t *testing.T) {
-	db := emptyDB()
-	defer db.Close()
+	t.Parallel()
 
-	const gitSha = "abc123"
-	err := Migrate(db, gitSha)
-	require.NoError(t, err)
+	t.Run("happy path", func(t *testing.T) {
+		db := emptyDB()
+		defer db.Close()
 
-	// idempotent
-	err = Migrate(db, gitSha)
-	require.NoError(t, err)
+		const gitSha = "abc123"
+		err := Migrate(db, gitSha)
+		require.NoError(t, err)
 
-	row := db.QueryRow(`select count(*) from schema_version`)
-	var count int
-	err = row.Scan(&count)
+		// idempotent
+		err = Migrate(db, gitSha)
+		require.NoError(t, err)
 
-	require.NoError(t, err)
-	require.Equal(t, 1, count)
+		row := db.QueryRow(`select count(*) from schema_version`)
+		var count int
+		err = row.Scan(&count)
 
-	err = Migrate(db, "new-sha")
-	require.NoError(t, err)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
 
-	row = db.QueryRow(`select count(*) from schema_version`)
-	err = row.Scan(&count)
+		err = Migrate(db, "new-sha")
+		require.NoError(t, err)
 
-	require.NoError(t, err)
-	require.Equal(t, 2, count)
+		row = db.QueryRow(`select count(*) from schema_version`)
+		err = row.Scan(&count)
 
-	row = db.QueryRow(`select git_sha from schema_version order by id desc limit 1`)
-	var gotSha string
-	err = row.Scan(&gotSha)
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
 
-	require.NoError(t, err)
-	require.Equal(t, "new-sha", gotSha)
+		row = db.QueryRow(`select git_sha from schema_version order by id desc limit 1`)
+		var gotSha string
+		err = row.Scan(&gotSha)
+
+		require.NoError(t, err)
+		require.Equal(t, "new-sha", gotSha)
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		// Start with an existing schema.
+		db := migratedDB()
+		defer db.Close()
+
+		// Migrate against the existing schema.
+		err := Migrate(db, "abc123")
+		require.NoError(t, err)
+	})
 }

--- a/internal/blockdb/migrate_test.go
+++ b/internal/blockdb/migrate_test.go
@@ -9,49 +9,37 @@ import (
 func TestMigrate(t *testing.T) {
 	t.Parallel()
 
-	t.Run("happy path", func(t *testing.T) {
-		db := emptyDB()
-		defer db.Close()
+	db := emptyDB()
+	defer db.Close()
 
-		const gitSha = "abc123"
-		err := Migrate(db, gitSha)
-		require.NoError(t, err)
+	const gitSha = "abc123"
+	err := Migrate(db, gitSha)
+	require.NoError(t, err)
 
-		// idempotent
-		err = Migrate(db, gitSha)
-		require.NoError(t, err)
+	// Tests idempotency.
+	err = Migrate(db, gitSha)
+	require.NoError(t, err)
 
-		row := db.QueryRow(`select count(*) from schema_version`)
-		var count int
-		err = row.Scan(&count)
+	row := db.QueryRow(`select count(*) from schema_version`)
+	var count int
+	err = row.Scan(&count)
 
-		require.NoError(t, err)
-		require.Equal(t, 1, count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
 
-		err = Migrate(db, "new-sha")
-		require.NoError(t, err)
+	err = Migrate(db, "new-sha")
+	require.NoError(t, err)
 
-		row = db.QueryRow(`select count(*) from schema_version`)
-		err = row.Scan(&count)
+	row = db.QueryRow(`select count(*) from schema_version`)
+	err = row.Scan(&count)
 
-		require.NoError(t, err)
-		require.Equal(t, 2, count)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
 
-		row = db.QueryRow(`select git_sha from schema_version order by id desc limit 1`)
-		var gotSha string
-		err = row.Scan(&gotSha)
+	row = db.QueryRow(`select git_sha from schema_version order by id desc limit 1`)
+	var gotSha string
+	err = row.Scan(&gotSha)
 
-		require.NoError(t, err)
-		require.Equal(t, "new-sha", gotSha)
-	})
-
-	t.Run("idempotent", func(t *testing.T) {
-		// Start with an existing schema.
-		db := migratedDB()
-		defer db.Close()
-
-		// Migrate against the existing schema.
-		err := Migrate(db, "abc123")
-		require.NoError(t, err)
-	})
+	require.NoError(t, err)
+	require.Equal(t, "new-sha", gotSha)
 }

--- a/internal/blockdb/test_case.go
+++ b/internal/blockdb/test_case.go
@@ -28,7 +28,7 @@ func CreateTestCase(ctx context.Context, db *sql.DB, testName, gitSha string) (*
 }
 
 // AddChain tracks and attaches a chain to the test case.
-// The chainID must be globally unique. E.g. osmosis-1001, cosmos-1004
+// The chainID must be unique per test case. E.g. osmosis-1001, cosmos-1004
 // The chainType denotes which ecosystem the chain belongs to. E.g. cosmos, penumbra, composable, etc.
 func (tc *TestCase) AddChain(ctx context.Context, chainID, chainType string) (*Chain, error) {
 	res, err := tc.db.ExecContext(ctx, `INSERT INTO chain(chain_id, chain_type, fk_test_id) VALUES(?, ?, ?)`, chainID, chainType, tc.id)

--- a/internal/blockdb/test_case.go
+++ b/internal/blockdb/test_case.go
@@ -29,8 +29,9 @@ func CreateTestCase(ctx context.Context, db *sql.DB, testName, gitSha string) (*
 
 // AddChain tracks and attaches a chain to the test case.
 // The chainID must be globally unique. E.g. osmosis-1001, cosmos-1004
-func (tc *TestCase) AddChain(ctx context.Context, chainID string) (*Chain, error) {
-	res, err := tc.db.ExecContext(ctx, `INSERT INTO chain(chain_id, fk_test_id) VALUES(?, ?)`, chainID, tc.id)
+// The chainType denotes which ecosystem the chain belongs to. E.g. cosmos, penumbra, composable, etc.
+func (tc *TestCase) AddChain(ctx context.Context, chainID, chainType string) (*Chain, error) {
+	res, err := tc.db.ExecContext(ctx, `INSERT INTO chain(chain_id, chain_type, fk_test_id) VALUES(?, ?, ?)`, chainID, chainType, tc.id)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/blockdb/test_case_test.go
+++ b/internal/blockdb/test_case_test.go
@@ -45,7 +45,7 @@ func TestCreateTestCase(t *testing.T) {
 	})
 }
 
-func TestTestCase_WithChain(t *testing.T) {
+func TestTestCase_AddChain(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -57,23 +57,25 @@ func TestTestCase_WithChain(t *testing.T) {
 		tc, err := CreateTestCase(ctx, db, "SomeTest", "abc")
 		require.NoError(t, err)
 
-		chain, err := tc.AddChain(ctx, "my-chain1")
+		chain, err := tc.AddChain(ctx, "my-chain1", "penumbra")
 		require.NoError(t, err)
 		require.NotNil(t, chain)
 
-		row := db.QueryRow(`SELECT chain_id, fk_test_id, id FROM chain`)
+		row := db.QueryRow(`SELECT chain_id, chain_type, fk_test_id, id FROM chain`)
 		var (
 			gotChainID    string
+			gotChainType  string
 			gotTestID     int
 			gotPrimaryKey int64
 		)
-		err = row.Scan(&gotChainID, &gotTestID, &gotPrimaryKey)
+		err = row.Scan(&gotChainID, &gotChainType, &gotTestID, &gotPrimaryKey)
 		require.NoError(t, err)
 		require.Equal(t, "my-chain1", gotChainID)
+		require.Equal(t, "penumbra", gotChainType)
 		require.Equal(t, 1, gotTestID)
 		require.EqualValues(t, 1, gotPrimaryKey)
 
-		_, err = tc.AddChain(ctx, "my-chain2")
+		_, err = tc.AddChain(ctx, "my-chain2", "test")
 		require.NoError(t, err)
 	})
 
@@ -84,10 +86,10 @@ func TestTestCase_WithChain(t *testing.T) {
 		tc, err := CreateTestCase(ctx, db, "SomeTest", "abc")
 		require.NoError(t, err)
 
-		_, err = tc.AddChain(ctx, "my-chain")
+		_, err = tc.AddChain(ctx, "my-chain", "cosmos")
 		require.NoError(t, err)
 
-		_, err = tc.AddChain(ctx, "my-chain")
+		_, err = tc.AddChain(ctx, "my-chain", "cosmos")
 		require.Error(t, err)
 	})
 }

--- a/internal/blockdb/views_test.go
+++ b/internal/blockdb/views_test.go
@@ -20,7 +20,7 @@ func TestTxFlattenedView(t *testing.T) {
 	tc, err := CreateTestCase(ctx, db, "mytest", "abc123")
 	require.NoError(t, err)
 
-	chain, err := tc.AddChain(ctx, "chain1")
+	chain, err := tc.AddChain(ctx, "chain1", "cosmos")
 	require.NoError(t, err)
 
 	beforeBlocksCreated := time.Now().UTC().Format(time.RFC3339)
@@ -40,6 +40,7 @@ func TestTxFlattenedView(t *testing.T) {
 
 		chainKeyID int64
 		chainID    string
+		chainType  string
 
 		blockID        int
 		blockCreatedAt string
@@ -50,7 +51,7 @@ func TestTxFlattenedView(t *testing.T) {
 	)
 	rows, err := db.Query(`SELECT
   test_case_id, test_case_created_at, test_case_name,
-  chain_kid, chain_id,
+  chain_kid, chain_id, chain_type,
   block_id, block_created_at, block_height,
   tx_id, tx
 FROM v_tx_flattened
@@ -63,7 +64,7 @@ ORDER BY test_case_id, chain_kid, block_id, tx_id
 	require.True(t, rows.Next())
 	require.NoError(t, rows.Scan(
 		&tcID, &tcCreatedAt, &tcName,
-		&chainKeyID, &chainID,
+		&chainKeyID, &chainID, &chainType,
 		&blockID, &blockCreatedAt, &blockHeight,
 		&txID, &tx,
 	))
@@ -75,6 +76,7 @@ ORDER BY test_case_id, chain_kid, block_id, tx_id
 
 	require.Equal(t, chainKeyID, chain.id)
 	require.Equal(t, chainID, "chain1")
+	require.Equal(t, chainType, "cosmos")
 
 	require.GreaterOrEqual(t, blockCreatedAt, beforeBlocksCreated)
 	require.LessOrEqual(t, blockCreatedAt, afterBlocksCreated)
@@ -90,7 +92,7 @@ ORDER BY test_case_id, chain_kid, block_id, tx_id
 	require.True(t, rows.Next())
 	require.NoError(t, rows.Scan(
 		&tcID, &tcCreatedAt, &tcName,
-		&chainKeyID, &chainID,
+		&chainKeyID, &chainID, &chainType,
 		&blockID, &blockCreatedAt, &blockHeight,
 		&txID, &tx,
 	))
@@ -114,7 +116,7 @@ ORDER BY test_case_id, chain_kid, block_id, tx_id
 	require.True(t, rows.Next())
 	require.NoError(t, rows.Scan(
 		&tcID, &tcCreatedAt, &tcName,
-		&chainKeyID, &chainID,
+		&chainKeyID, &chainID, &chainType,
 		&blockID, &blockCreatedAt, &blockHeight,
 		&txID, &tx,
 	))


### PR DESCRIPTION
Given ibctest supports many types of chains, we need to be explicit about the chain type (ecosystem). Any debugging tools can leverage this extra dimension to present more advanced debugging options for cosmos like the messages view from https://github.com/strangelove-ventures/ibctest/pull/133.

Supports: https://github.com/strangelove-ventures/ibctest/issues/123