### PR TITLE
Add FlushPackets and FlushAcknowledgements to ibc.Relayer

### DIFF
--- a/conformance/flush.go
+++ b/conformance/flush.go
@@ -94,7 +94,7 @@ func TestRelayerFlushing(t *testing.T, cf ibctest.ChainFactory, rf ibctest.Relay
 		// Should trigger MsgRecvPacket.
 		req.NoError(r.FlushPackets(ctx, eRep, pathName, c0ChannelID))
 
-		test.WaitForBlocks(ctx, 3, c0, c1)
+		req.NoError(test.WaitForBlocks(ctx, 3, c0, c1))
 
 		req.NoError(r.FlushPackets(ctx, eRep, pathName, c1ChannelID))
 

--- a/conformance/flush.go
+++ b/conformance/flush.go
@@ -1,0 +1,125 @@
+package conformance
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/relayer"
+	"github.com/strangelove-ventures/ibctest/test"
+	"github.com/strangelove-ventures/ibctest/testreporter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelayerFlushing(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory, rep *testreporter.Reporter) {
+	rep.TrackTest(t)
+
+	// FlushPackets will be exercised in a subtest,
+	// but check that capability first in case we can avoid setup.
+	requireCapabilities(t, rep, rf, relayer.FlushPackets)
+
+	home := t.TempDir()
+	pool, network := ibctest.DockerSetup(t)
+
+	req := require.New(rep.TestifyT(t))
+	chains, err := cf.Chains(t.Name())
+	req.NoError(err, "failed to get chains")
+
+	if len(chains) != 2 {
+		panic(fmt.Errorf("expected 2 chains, got %d", len(chains)))
+	}
+
+	c0, c1 := chains[0], chains[1]
+
+	r := rf.Build(t, pool, network, home)
+
+	const pathName = "p"
+	ic := ibctest.NewInterchain().
+		AddChain(c0).
+		AddChain(c1).
+		AddRelayer(r, "r").
+		AddLink(ibctest.InterchainLink{
+			Chain1:  c0,
+			Chain2:  c1,
+			Relayer: r,
+
+			Path: pathName,
+		})
+
+	ctx := context.Background()
+	eRep := rep.RelayerExecReporter(t)
+
+	req.NoError(ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
+		TestName:  t.Name(),
+		HomeDir:   home,
+		Pool:      pool,
+		NetworkID: network,
+	}))
+
+	// Get faucet address on destination chain for ibc transfer.
+	c1FaucetAddrBytes, err := c1.GetAddress(ctx, ibctest.FaucetAccountKeyName)
+	req.NoError(err)
+	c1FaucetAddr, err := types.Bech32ifyAddressBytes(c1.Config().Bech32Prefix, c1FaucetAddrBytes)
+	req.NoError(err)
+
+	channels, err := r.GetChannels(ctx, eRep, c0.Config().ChainID)
+	req.NoError(err)
+	req.Len(channels, 1)
+
+	c0ChannelID := channels[0].ChannelID
+	c1ChannelID := channels[0].Counterparty.ChannelID
+
+	beforeTransferHeight, err := c0.Height(ctx)
+	req.NoError(err)
+
+	const txAmount = 112233 // Arbitrary amount that is easy to find in logs.
+	tx, err := c0.SendIBCTransfer(ctx, c0ChannelID, ibctest.FaucetAccountKeyName, ibc.WalletAmount{
+		Address: c1FaucetAddr,
+		Denom:   c0.Config().Denom,
+		Amount:  txAmount,
+	}, nil)
+	req.NoError(err)
+	req.NoError(tx.Validate())
+
+	t.Run("flush packets", func(t *testing.T) {
+		rep.TrackTest(t)
+
+		eRep := rep.RelayerExecReporter(t)
+
+		req := require.New(rep.TestifyT(t))
+
+		// Should trigger MsgRecvPacket.
+		req.NoError(r.FlushPackets(ctx, eRep, pathName, c0ChannelID))
+
+		test.WaitForBlocks(ctx, 3, c0, c1)
+
+		req.NoError(r.FlushPackets(ctx, eRep, pathName, c1ChannelID))
+
+		afterFlushHeight, err := c0.Height(ctx)
+		req.NoError(err)
+
+		// Ack shouldn't happen yet.
+		_, err = test.PollForAck(ctx, c0, beforeTransferHeight, afterFlushHeight+2, tx.Packet)
+		req.ErrorIs(err, test.ErrNotFound)
+	})
+
+	t.Run("flush acks", func(t *testing.T) {
+		rep.TrackTest(t)
+		requireCapabilities(t, rep, rf, relayer.FlushAcknowledgements)
+
+		eRep := rep.RelayerExecReporter(t)
+
+		req := require.New(rep.TestifyT(t))
+		req.NoError(r.FlushAcknowledgements(ctx, eRep, pathName, c0ChannelID))
+
+		afterFlushHeight, err := c0.Height(ctx)
+		req.NoError(err)
+
+		// Now the ack must be present.
+		_, err = test.PollForAck(ctx, c0, beforeTransferHeight, afterFlushHeight+2, tx.Packet)
+		req.NoError(err)
+	})
+}

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -235,6 +235,13 @@ func Test(t *testing.T, cfs []ibctest.ChainFactory, rfs []ibctest.RelayerFactory
 
 								TestChainPair(t, cf, rf, rep)
 							})
+
+							t.Run("flushing", func(t *testing.T) {
+								rep.TrackTest(t)
+								rep.TrackParallel(t)
+
+								TestRelayerFlushing(t, cf, rf, rep)
+							})
 						})
 					}
 				})

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -50,8 +50,11 @@ type Relayer interface {
 	// StopRelayer stops a relayer that started work through StartRelayer.
 	StopRelayer(ctx context.Context, rep RelayerExecReporter) error
 
-	// relay queue until it is empty
-	ClearQueue(ctx context.Context, rep RelayerExecReporter, pathName string, channelID string) error
+	// FlushPackets flushes any outstanding packets and then returns.
+	FlushPackets(ctx context.Context, rep RelayerExecReporter, pathName string, channelID string) error
+
+	// FlushAcknowledgements flushes any outstanding acknowledgements and then returns.
+	FlushAcknowledgements(ctx context.Context, rep RelayerExecReporter, pathName string, channelID string) error
 
 	// CreateClients performs the client handshake steps necessary for creating a light client
 	// on src that tracks the state of dst, and a light client on dst that tracks the state of src.

--- a/internal/blockdb/messages_view_test.go
+++ b/internal/blockdb/messages_view_test.go
@@ -187,9 +187,6 @@ WHERE type = "/ibc.core.connection.v1.MsgConnectionOpenConfirm" AND chain_id = ?
 		gaia0ChannelID = channels[0].ChannelID
 		gaia1ChannelID = channels[0].Counterparty.ChannelID
 
-		_ = gaia0ChannelID
-		_ = gaia1ChannelID
-
 		// OpenInit happens on first chain.
 		const qChannelOpenInit = `SELECT
 port_id, counterparty_port_id
@@ -271,7 +268,7 @@ WHERE type = "/ibc.applications.transfer.v1.MsgTransfer" AND chain_id = ?
 	}
 
 	t.Run("relay packet", func(t *testing.T) {
-		require.NoError(t, r.ClearQueue(ctx, eRep, pathName, gaia0ChannelID))
+		require.NoError(t, r.FlushPackets(ctx, eRep, pathName, gaia0ChannelID))
 
 		const qMsgRecvPacket = `SELECT
 port_id, channel_id, counterparty_port_id, counterparty_channel_id
@@ -286,5 +283,6 @@ WHERE type = "/ibc.core.channel.v1.MsgRecvPacket" AND chain_id = ?
 	})
 
 	// TODO: relay acknowledgement.
-	// Blocked on ibc.Relayer.ClearQueue needing replaced with RelayPackets, RelayAcks.
+	// Waiting for next relayer release candidate,
+	// so that this test doesn't need to conditionally skip based on whether FlushAcknowledgements is supported.
 }

--- a/relayer/capability.go
+++ b/relayer/capability.go
@@ -14,6 +14,10 @@ type Capability int
 const (
 	TimestampTimeout Capability = iota
 	HeightTimeout
+
+	// Whether the relayer supports a one-off flush packets or flush acknowledgements command.
+	FlushPackets
+	FlushAcknowledgements
 )
 
 // FullCapabilities returns a mapping of all known relayer features to true,
@@ -24,5 +28,8 @@ func FullCapabilities() map[Capability]bool {
 	return map[Capability]bool{
 		TimestampTimeout: true,
 		HeightTimeout:    true,
+
+		FlushPackets:          true,
+		FlushAcknowledgements: true,
 	}
 }

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -120,11 +120,6 @@ func (r *DockerRelayer) AddKey(ctx context.Context, rep ibc.RelayerExecReporter,
 	return r.c.ParseAddKeyOutput(stdout, stderr)
 }
 
-func (r *DockerRelayer) ClearQueue(ctx context.Context, rep ibc.RelayerExecReporter, pathName, channelID string) error {
-	cmd := r.c.ClearQueue(pathName, channelID, r.NodeHome())
-	return dockerutil.HandleNodeJobError(r.NodeJob(ctx, rep, cmd))
-}
-
 func (r *DockerRelayer) CreateChannel(ctx context.Context, rep ibc.RelayerExecReporter, pathName string, opts ibc.CreateChannelOptions) error {
 	cmd := r.c.CreateChannel(pathName, opts, r.NodeHome())
 	return dockerutil.HandleNodeJobError(r.NodeJob(ctx, rep, cmd))
@@ -137,6 +132,16 @@ func (r *DockerRelayer) CreateClients(ctx context.Context, rep ibc.RelayerExecRe
 
 func (r *DockerRelayer) CreateConnections(ctx context.Context, rep ibc.RelayerExecReporter, pathName string) error {
 	cmd := r.c.CreateConnections(pathName, r.NodeHome())
+	return dockerutil.HandleNodeJobError(r.NodeJob(ctx, rep, cmd))
+}
+
+func (r *DockerRelayer) FlushAcknowledgements(ctx context.Context, rep ibc.RelayerExecReporter, pathName, channelID string) error {
+	cmd := r.c.FlushAcknowledgements(pathName, channelID, r.NodeHome())
+	return dockerutil.HandleNodeJobError(r.NodeJob(ctx, rep, cmd))
+}
+
+func (r *DockerRelayer) FlushPackets(ctx context.Context, rep ibc.RelayerExecReporter, pathName, channelID string) error {
+	cmd := r.c.FlushPackets(pathName, channelID, r.NodeHome())
 	return dockerutil.HandleNodeJobError(r.NodeJob(ctx, rep, cmd))
 }
 
@@ -421,10 +426,11 @@ type RelayerCommander interface {
 
 	AddChainConfiguration(containerFilePath, homeDir string) []string
 	AddKey(chainID, keyName, homeDir string) []string
-	ClearQueue(pathName, channelID, homeDir string) []string
 	CreateChannel(pathName string, opts ibc.CreateChannelOptions, homeDir string) []string
 	CreateClients(pathName, homeDir string) []string
 	CreateConnections(pathName, homeDir string) []string
+	FlushAcknowledgements(pathName, channelID, homeDir string) []string
+	FlushPackets(pathName, channelID, homeDir string) []string
 	GeneratePath(srcChainID, dstChainID, pathName, homeDir string) []string
 	GetChannels(chainID, homeDir string) []string
 	GetConnections(chainID, homeDir string) []string

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -65,7 +65,12 @@ const (
 // to distinguish between multiple rly versions.
 func Capabilities() map[relayer.Capability]bool {
 	m := relayer.FullCapabilities()
+
+	// These two capabilities are not supported in the 2.0.0-beta4 tag,
+	// but they do work on the current main branch of relayer.
+	// The first 2.0 release candidate should be able to have full capabilities.
 	m[relayer.TimestampTimeout] = false
+	m[relayer.FlushAcknowledgements] = false
 	return m
 }
 
@@ -112,13 +117,6 @@ func (commander) AddKey(chainID, keyName, homeDir string) []string {
 	}
 }
 
-func (commander) ClearQueue(pathName, channelID, homeDir string) []string {
-	return []string{
-		"rly", "tx", "relay-pkts", pathName, channelID,
-		"--home", homeDir,
-	}
-}
-
 func (commander) CreateChannel(pathName string, opts ibc.CreateChannelOptions, homeDir string) []string {
 	return []string{
 		"rly", "tx", "channel", pathName,
@@ -141,6 +139,20 @@ func (commander) CreateClients(pathName, homeDir string) []string {
 func (commander) CreateConnections(pathName, homeDir string) []string {
 	return []string{
 		"rly", "tx", "connection", pathName,
+		"--home", homeDir,
+	}
+}
+
+func (commander) FlushAcknowledgements(pathName, channelID, homeDir string) []string {
+	return []string{
+		"rly", "tx", "relay-acks", pathName, channelID,
+		"--home", homeDir,
+	}
+}
+
+func (commander) FlushPackets(pathName, channelID, homeDir string) []string {
+	return []string{
+		"rly", "tx", "relay-pkts", pathName, channelID,
 		"--home", homeDir,
 	}
 }


### PR DESCRIPTION
The previous ClearQueue method only flushed packets.

Both FlushPackets and FlushAcknowledgements are intended to be run as
one-off commands that do one chunk of work and stop. This is useful for
tests that need to make one unit of progress before making a set of
assertions.

In the future we may add a function like ClearQueue to the test package,
but for now the choices are StartRelayer, or manual flushing.
