### PR TITLE
fix: Intermittent panic when WaitForBlocks height is 0

### DIFF
--- a/test/wait_for_blocks.go
+++ b/test/wait_for_blocks.go
@@ -41,7 +41,7 @@ func (h *height) WaitForDelta(ctx context.Context, delta int) error {
 			return err
 		}
 		if cur == 0 {
-			panic("height cannot be zero")
+			continue
 		}
 		h.update(cur)
 	}

--- a/test/wait_for_blocks.go
+++ b/test/wait_for_blocks.go
@@ -40,6 +40,8 @@ func (h *height) WaitForDelta(ctx context.Context, delta int) error {
 		if err != nil {
 			return err
 		}
+		// We assume the chain will eventually return a non-zero height, otherwise
+		// this may block indefinitely.
 		if cur == 0 {
 			continue
 		}

--- a/test/wait_for_blocks.go
+++ b/test/wait_for_blocks.go
@@ -12,6 +12,7 @@ type ChainHeighter interface {
 }
 
 // WaitForBlocks blocks until all chains reach a block height delta equal to or greater than the delta argument.
+// If a ChainHeighter does not monotonically increase the height, this function may block program execution indefinitely.
 func WaitForBlocks(ctx context.Context, delta int, chains ...ChainHeighter) error {
 	if len(chains) == 0 {
 		panic("missing chains")


### PR DESCRIPTION
Resolves https://github.com/strangelove-ventures/ibctest/issues/130

The tradeoff to this fix is that if a chain always returns 0 height, `WaitForBlocks` could block indefinitely. However, we've already made the assumption a chain monotonically increases its height. If not, `WaitForBlocks` may block program execution.

We could take steps to mitigate, but my assumption is the above scenario is highly unlikely. 