### PR TITLE
chore: Run code generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help: ## Print this help message
 	@echo "Available make commands:"; grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: ibctest
-ibctest: ## Build ibctest binary into ./bin
+ibctest: gen ## Build ibctest binary into ./bin
 	go test -ldflags "-X github.com/strangelove-ventures/ibctest/internal/version.GitSha=$(shell git describe --always --dirty)" -c -o ./bin/ibctest ./cmd/ibctest
 
 .PHONY: test
@@ -20,3 +20,7 @@ docker-reset: ## Attempt to delete all running containers. Useful if ibctest doe
 .PHONY: docker-mac-nuke
 docker-mac-nuke: ## macOS only. Try docker-reset first. Kills and restarts Docker Desktop.
 	killall -9 Docker && open /Applications/Docker.app
+
+.PHONY: gen
+gen: ## Run code generators
+	go generate ./...


### PR DESCRIPTION
# Description, Motivation, and Context

Easy to forget to run `go generate`. 

Code generation is run as part of creating the ibctest binary, `make ibctest`.

## Known Limitations, Trade-offs, Tech Debt
* May slightly slow down creating the binary.
* I've had CI steps that fail if code generation causes a dirty git state. But I don't think we need to go that far now.