### PR TITLE
Use timeouts for some docker operations

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -309,6 +309,12 @@ func (tn *ChainNode) AddGenesisAccount(ctx context.Context, address string, gene
 	}
 	tn.lock.Lock()
 	defer tn.lock.Unlock()
+
+	// Adding a genesis account should complete instantly,
+	// so use a 1-minute timeout to more quickly detect if Docker has locked up.
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
 	return dockerutil.HandleNodeJobError(tn.NodeJob(ctx, command))
 }
 

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -132,6 +132,12 @@ func (p *PenumbraAppNode) ValidatorPrivateKeyFile(nodeNum int) string {
 
 func (p *PenumbraAppNode) Cleanup(ctx context.Context) error {
 	cmd := []string{"find", fmt.Sprintf("%s/.", p.NodeHome()), "-name", ".", "-o", "-prune", "-exec", "rm", "-rf", "--", "{}", "+"}
+
+	// Cleanup should complete instantly,
+	// so add a 1-minute timeout in case Docker hangs.
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
 	return dockerutil.HandleNodeJobError(p.NodeJob(ctx, cmd))
 }
 


### PR DESCRIPTION
I continue to see regular hangs in Docker. I've added context timeouts
in a few places where commands should complete quickly, and I've updated
the docker wrapper for the relayer to respect context cancellation in
more docker API calls.

Now, instead of waiting for go test's default 10m timeout when a
container gets stuck in the Created state, you may instead see a context
deadline exceeded error like this:

    failed to restore key to relayer r for chain g0: context deadline exceeded