### PR TITLE
feat: Add search feature to debug TUI

### DIFF
--- a/internal/blockdb/tui/help.go
+++ b/internal/blockdb/tui/help.go
@@ -42,7 +42,11 @@ var (
 	keyMap = map[mainContent][]keyBinding{
 		testCasesMain:      bindingsWithBase([]keyBinding{{"m", "cosmos messages"}, {"enter", "view txs"}}, tableNavKeys),
 		cosmosMessagesMain: bindingsWithBase(tableNavKeys),
-		txDetailMain:       bindingsWithBase([]keyBinding{{"[", "previous tx"}, {"]", "next tx"}}, textNavKeys),
+		txDetailMain: bindingsWithBase([]keyBinding{
+			{"[", "previous tx"},
+			{"]", "next tx"},
+			{"/", "toggle search"},
+		}, textNavKeys),
 	}
 )
 

--- a/internal/blockdb/tui/presenter/highlight.go
+++ b/internal/blockdb/tui/presenter/highlight.go
@@ -1,0 +1,41 @@
+package presenter
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+type Highlight struct {
+	regionText string
+	regions    []string
+}
+
+// NewHighlight returns a presenter that adds regions around text that matches searchTerm.
+func NewHighlight(fullText string, searchTerm string) *Highlight {
+	r, err := regexp.Compile(fmt.Sprintf(`(?is)(%s)`, regexp.QuoteMeta(searchTerm)))
+	if err != nil {
+		// Should always be valid given regexp.QuoteMeta above.
+		panic(err)
+	}
+	h := &Highlight{}
+	var i int
+	text := r.ReplaceAllStringFunc(fullText, func(s string) string {
+		region := strconv.Itoa(i)
+		h.regions = append(h.regions, region)
+		s = fmt.Sprintf(`["%s"]%s[""]`, region, s)
+		i++
+		return s
+	})
+	h.regionText = text
+
+	return h
+}
+
+// Text returns the text decorated with tview.TextView regions given the "searchTerm" from NewHighlight.
+func (h *Highlight) Text() string { return h.regionText }
+
+// Regions returns all region ids.
+// Meant to pair with (*tview.TextView).Highlight and ScrollToHighlight
+// See https://github.com/rivo/tview/wiki/TextView for an example.
+func (h *Highlight) Regions() []string { return h.regions }

--- a/internal/blockdb/tui/presenter/highlight.go
+++ b/internal/blockdb/tui/presenter/highlight.go
@@ -17,12 +17,13 @@ func NewHighlight(searchTerm string) *Highlight {
 	if searchTerm == "" {
 		return &Highlight{}
 	}
-	// Should always be valid given regexp.QuoteMeta above.
+	// Should always be valid with regexp.QuoteMeta.
 	return &Highlight{rx: regexp.MustCompile(fmt.Sprintf(`(?is)(%s)`, regexp.QuoteMeta(searchTerm)))}
 }
 
 // Text returns the text decorated with tview.TextView regions given the "searchTerm" from NewHighlight.
 // The second return value is the highlighted region ids for use with *(tview.TextView).Highlight.
+// See https://github.com/rivo/tview/wiki/TextView for more info about regions.
 func (h *Highlight) Text(text string) (string, []string) {
 	if h.rx == nil {
 		return text, nil

--- a/internal/blockdb/tui/presenter/highlight.go
+++ b/internal/blockdb/tui/presenter/highlight.go
@@ -18,7 +18,7 @@ func NewHighlight(searchTerm string) *Highlight {
 		return &Highlight{}
 	}
 	// Should always be valid with regexp.QuoteMeta.
-	return &Highlight{rx: regexp.MustCompile(fmt.Sprintf(`(?is)(%s)`, regexp.QuoteMeta(searchTerm)))}
+	return &Highlight{rx: regexp.MustCompile(fmt.Sprintf(`(?i)(%s)`, regexp.QuoteMeta(searchTerm)))}
 }
 
 // Text returns the text decorated with tview.TextView regions given the "searchTerm" from NewHighlight.

--- a/internal/blockdb/tui/presenter/highlight_test.go
+++ b/internal/blockdb/tui/presenter/highlight_test.go
@@ -1,0 +1,39 @@
+package presenter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHighlighter_Text(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		h := NewHighlight(highlighterFixture, "Day")
+
+		const want = `Tomorrow, and tomorrow, and tomorrow,
+Creeps in this petty pace from ["0"]day[""] to ["1"]day[""],
+To the last syllable of recorded time;
+And all our yester["2"]day[""]s have lighted fools
+The way to dusty death. Out, out, brief candle!`
+
+		require.Equal(t, want, h.Text())
+	})
+
+	t.Run("ignores regex meta characters", func(t *testing.T) {
+		h := NewHighlight("(one paren", "(one paren")
+
+		require.Equal(t, `["0"](one paren[""]`, h.Text())
+	})
+}
+
+func TestHighlighter_Regions(t *testing.T) {
+	h := NewHighlight(highlighterFixture, "Day")
+
+	require.Equal(t, []string{"0", "1", "2"}, h.Regions())
+}
+
+const highlighterFixture = `Tomorrow, and tomorrow, and tomorrow,
+Creeps in this petty pace from day to day,
+To the last syllable of recorded time;
+And all our yesterdays have lighted fools
+The way to dusty death. Out, out, brief candle!`

--- a/internal/blockdb/tui/presenter/highlight_test.go
+++ b/internal/blockdb/tui/presenter/highlight_test.go
@@ -8,28 +8,40 @@ import (
 
 func TestHighlighter_Text(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		h := NewHighlight(highlighterFixture, "Day")
+		h := NewHighlight("\tDay ")
+
+		got, regions := h.Text(highlighterFixture)
 
 		const want = `Tomorrow, and tomorrow, and tomorrow,
 Creeps in this petty pace from ["0"]day[""] to ["1"]day[""],
 To the last syllable of recorded time;
 And all our yester["2"]day[""]s have lighted fools
 The way to dusty death. Out, out, brief candle!`
-
-		require.Equal(t, want, h.Text())
+		require.Equal(t, want, got)
+		require.Equal(t, []string{"0", "1", "2"}, regions)
 	})
 
 	t.Run("ignores regex meta characters", func(t *testing.T) {
-		h := NewHighlight("(one paren", "(one paren")
+		h := NewHighlight("(one paren")
+		got, regions := h.Text("(one paren")
 
-		require.Equal(t, `["0"](one paren[""]`, h.Text())
+		require.Equal(t, `["0"](one paren[""]`, got)
+		require.Equal(t, []string{"0"}, regions)
 	})
-}
 
-func TestHighlighter_Regions(t *testing.T) {
-	h := NewHighlight(highlighterFixture, "Day")
+	t.Run("missing search term", func(t *testing.T) {
+		h := NewHighlight("")
+		got, regions := h.Text(highlighterFixture)
 
-	require.Equal(t, []string{"0", "1", "2"}, h.Regions())
+		require.Empty(t, regions)
+		require.Equal(t, highlighterFixture, got)
+
+		h = NewHighlight("          \t")
+		got, regions = h.Text(highlighterFixture)
+
+		require.Empty(t, regions)
+		require.Equal(t, highlighterFixture, got)
+	})
 }
 
 const highlighterFixture = `Tomorrow, and tomorrow, and tomorrow,

--- a/internal/blockdb/tui/update.go
+++ b/internal/blockdb/tui/update.go
@@ -58,6 +58,11 @@ func (m *Model) Update(ctx context.Context) func(event *tcell.EventKey) *tcell.E
 		case event.Rune() == '/' && m.stack.Current() == txDetailMain:
 			m.txDetailView().ToggleSearch()
 			return nil
+
+		case event.Key() == tcell.KeyEnter && m.stack.Current() == txDetailMain:
+			// Search tx detail.
+			m.txDetailView().DoSearch()
+			return nil
 		}
 
 		return event

--- a/internal/blockdb/tui/update.go
+++ b/internal/blockdb/tui/update.go
@@ -33,15 +33,7 @@ func (m *Model) Update(ctx context.Context) func(event *tcell.EventKey) *tcell.E
 				// TODO (nix - 6/14/22) Display error instead of panic.
 				panic(err)
 			}
-			m.pushMainView(txDetailMain, txDetailView(tc.ChainID, results))
-			return nil
-
-		case event.Rune() == '[' && m.stack.Current() == txDetailMain:
-			goToPrevPage(m.txDetailPages())
-			return nil
-
-		case event.Rune() == ']' && m.stack.Current() == txDetailMain:
-			gotToNextPage(m.txDetailPages())
+			m.pushMainView(txDetailMain, newTxDetailView(tc.ChainID, results))
 			return nil
 
 		case event.Rune() == 'm' && m.stack.Current() == testCasesMain:
@@ -55,6 +47,17 @@ func (m *Model) Update(ctx context.Context) func(event *tcell.EventKey) *tcell.E
 			m.pushMainView(cosmosMessagesMain, cosmosMessagesView(tc, results))
 			return nil
 
+		case event.Rune() == '[' && m.stack.Current() == txDetailMain:
+			goToPrevPage(m.txDetailView().Pages)
+			return nil
+
+		case event.Rune() == ']' && m.stack.Current() == txDetailMain:
+			gotToNextPage(m.txDetailView().Pages)
+			return nil
+
+		case event.Rune() == '/' && m.stack.Current() == txDetailMain:
+			m.txDetailView().ToggleSearch()
+			return nil
 		}
 
 		return event
@@ -86,10 +89,9 @@ func (m *Model) selectedRow() int {
 	return row - 1
 }
 
-func (m *Model) txDetailPages() *tview.Pages {
+func (m *Model) txDetailView() *txDetailView {
 	_, primitive := m.mainContentView().GetFrontPage()
-	// Tx details is a nested pages.
-	return primitive.(*tview.Pages)
+	return primitive.(*txDetailView)
 }
 
 // gotToNextPage assumes a convention where the page name is equal to its index. e.g. "0", "1", "2", etc.

--- a/internal/blockdb/tui/update_test.go
+++ b/internal/blockdb/tui/update_test.go
@@ -117,11 +117,14 @@ func TestModel_Update(t *testing.T) {
 
 		require.Equal(t, 2, model.mainContentView().GetPageCount())
 		_, primitive := model.mainContentView().GetFrontPage()
-		innerPages := primitive.(*tview.Pages)
+		txDetail := model.txDetailView()
 
-		require.Equal(t, 3, innerPages.GetPageCount())
+		// Search and text view
+		require.Equal(t, 2, txDetail.Flex.GetItemCount())
 
-		_, primitive = innerPages.GetFrontPage()
+		require.Equal(t, 3, txDetail.Pages.GetPageCount())
+
+		_, primitive = txDetail.Pages.GetFrontPage()
 		textView := primitive.(*tview.TextView)
 
 		require.Contains(t, textView.GetTitle(), "Tx 1 of 3")
@@ -134,7 +137,7 @@ func TestModel_Update(t *testing.T) {
 		// Move to the next page.
 		update(runKey(']'))
 
-		_, primitive = innerPages.GetFrontPage()
+		_, primitive = txDetail.Pages.GetFrontPage()
 		textView = primitive.(*tview.TextView)
 
 		require.Contains(t, textView.GetTitle(), "Tx 2 of 3")
@@ -149,7 +152,7 @@ func TestModel_Update(t *testing.T) {
 		update(runKey(']'))
 		update(runKey(']'))
 
-		_, primitive = innerPages.GetFrontPage()
+		_, primitive = txDetail.Pages.GetFrontPage()
 		textView = primitive.(*tview.TextView)
 
 		require.Contains(t, textView.GetTitle(), "Tx 3 of 3")
@@ -160,7 +163,7 @@ func TestModel_Update(t *testing.T) {
 		update(runKey('['))
 		update(runKey('['))
 
-		_, primitive = innerPages.GetFrontPage()
+		_, primitive = txDetail.Pages.GetFrontPage()
 		textView = primitive.(*tview.TextView)
 
 		require.Contains(t, textView.GetTitle(), "Tx 1 of 3")

--- a/internal/blockdb/tui/views.go
+++ b/internal/blockdb/tui/views.go
@@ -194,9 +194,6 @@ func (detail *txDetailView) ToggleSearch() {
 	detail.Pages.Blur()
 }
 
-func (detail *txDetailView) DoSearch() {
-}
-
 func (*txDetailView) buildPages(chainID string, txs []blockdb.TxResult) *tview.Pages {
 	pages := tview.NewPages()
 
@@ -230,6 +227,9 @@ func (*txDetailView) buildSearchInput() *tview.InputField {
 	input := tview.NewInputField().
 		SetFieldTextColor(searchInactiveColor).
 		SetFieldBackgroundColor(backgroundColor)
+
+	style := tcell.Style{}.Foreground(tcell.ColorDimGray).Background(backgroundColor)
+	input.SetPlaceholder("case insensitive regex").SetPlaceholderStyle(style)
 
 	input.SetTitle("Search").
 		SetTitleColor(searchInactiveColor).

--- a/internal/blockdb/tui/views.go
+++ b/internal/blockdb/tui/views.go
@@ -151,7 +151,7 @@ func cosmosMessagesView(tc blockdb.TestCaseResult, msgs []blockdb.CosmosMessageR
 }
 
 const (
-	searchActiveColor   = tcell.ColorYellow
+	searchActiveColor   = tcell.ColorPaleGreen
 	searchInactiveColor = tcell.ColorBlue
 )
 


### PR DESCRIPTION
# Description, Motivation, and Context

Allows users to search text which gets highlighted in the associated text view. 

The last TUI feature I'll tackle before calling this MVP done is the ability to download the txs as a JSON array in case the user wants to use alternate tools to slice and dice the txs.

## Demo

![tx-detail-search](https://user-images.githubusercontent.com/224251/174170828-fc743e38-7c25-4fc0-a8c7-33e20b19457c.gif)

## Known Limitations, Trade-offs, Tech Debt
* The UX may be a little confusing. It searches across all txs, highlighting all words so you can flip between txs without having to redo the search on every page.