### PR TITLE
Add tendermint events tables to blockdb

### DIFF
--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/strangelove-ventures/ibctest/chain/internal/tendermint"
 	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/internal/blockdb"
 	"github.com/strangelove-ventures/ibctest/internal/dockerutil"
 	"github.com/strangelove-ventures/ibctest/test"
 	"go.uber.org/zap"
@@ -656,6 +657,6 @@ func (c *CosmosChain) Timeouts(ctx context.Context, height uint64) ([]ibc.Packet
 }
 
 // FindTxs implements blockdb.BlockSaver.
-func (c *CosmosChain) FindTxs(ctx context.Context, height uint64) ([][]byte, error) {
+func (c *CosmosChain) FindTxs(ctx context.Context, height uint64) ([]blockdb.Tx, error) {
 	return c.getFullNode().FindTxs(ctx, height)
 }

--- a/internal/blockdb/chain.go
+++ b/internal/blockdb/chain.go
@@ -16,12 +16,12 @@ type Chain struct {
 	single singleflight.Group
 }
 
-type transactions [][]byte
+type transactions []Tx
 
 func (txs transactions) Hash() []byte {
 	h := fnv.New32()
 	for _, tx := range txs {
-		h.Write(tx)
+		h.Write(tx.Data)
 	}
 	return h.Sum(nil)
 }
@@ -29,7 +29,7 @@ func (txs transactions) Hash() []byte {
 // SaveBlock tracks a block at height with its transactions.
 // This method is idempotent and can be safely called multiple times with the same arguments.
 // The txs should be human-readable.
-func (chain *Chain) SaveBlock(ctx context.Context, height uint64, txs [][]byte) error {
+func (chain *Chain) SaveBlock(ctx context.Context, height uint64, txs []Tx) error {
 	k := fmt.Sprintf("%d-%x", height, transactions(txs).Hash())
 	_, err, _ := chain.single.Do(k, func() (interface{}, error) {
 		return nil, chain.saveBlock(ctx, height, txs)
@@ -54,7 +54,7 @@ func (chain *Chain) saveBlock(ctx context.Context, height uint64, txs transactio
 		return err
 	}
 	for _, tx := range txs {
-		_, err = dbTx.ExecContext(ctx, `INSERT INTO tx(data, fk_block_id) VALUES (?, ?)`, string(tx), blockID)
+		_, err = dbTx.ExecContext(ctx, `INSERT INTO tx(data, fk_block_id) VALUES (?, ?)`, string(tx.Data), blockID)
 		if err != nil {
 			return fmt.Errorf("insert into tx: %w", err)
 		}

--- a/internal/blockdb/chain_test.go
+++ b/internal/blockdb/chain_test.go
@@ -26,7 +26,24 @@ func TestChain_SaveBlock(t *testing.T) {
 	var (
 		ctx = context.Background()
 		tx1 = Tx{Data: []byte(`{"test":0}`)}
-		tx2 = Tx{Data: []byte(`{"test":1}`)}
+		tx2 = Tx{
+			Data: []byte(`{"test":1}`),
+			Events: []Event{
+				{
+					Type: "e1",
+					Attributes: []EventAttribute{
+						{Key: "k1", Value: "v1"},
+					},
+				},
+				{
+					Type: "e2",
+					Attributes: []EventAttribute{
+						{Key: "k2", Value: "v2"},
+						{Key: "k3", Value: "v3"},
+					},
+				},
+			},
+		}
 	)
 
 	t.Run("happy path", func(t *testing.T) {
@@ -69,6 +86,36 @@ func TestChain_SaveBlock(t *testing.T) {
 			i++
 		}
 		require.Equal(t, 2, i)
+
+		rows, err = db.Query(`SELECT
+tx.data, tendermint_events.type, key, value
+FROM tendermint_event_attrs
+LEFT JOIN tendermint_events ON tendermint_events.id = fk_event_id
+LEFT JOIN tx ON tx.id = tendermint_events.fk_tx_id
+ORDER BY tendermint_event_attrs.id`)
+		require.NoError(t, err)
+		defer rows.Close()
+		for i = 0; rows.Next(); i++ {
+			var gotData, gotType, gotKey, gotValue string
+			require.NoError(t, rows.Scan(&gotData, &gotType, &gotKey, &gotValue))
+			require.Equal(t, gotData, `{"test":1}`)
+			switch i {
+			case 0:
+				require.Equal(t, gotType, "e1")
+				require.Equal(t, gotKey, "k1")
+				require.Equal(t, gotValue, "v1")
+			case 1:
+				require.Equal(t, gotType, "e2")
+				require.Equal(t, gotKey, "k2")
+				require.Equal(t, gotValue, "v2")
+			case 2:
+				require.Equal(t, gotType, "e2")
+				require.Equal(t, gotKey, "k3")
+				require.Equal(t, gotValue, "v3")
+			default:
+				t.Fatalf("expected 3 results, got i=%d", i)
+			}
+		}
 	})
 
 	t.Run("idempotent", func(t *testing.T) {
@@ -77,9 +124,9 @@ func TestChain_SaveBlock(t *testing.T) {
 
 		chain := validChain(t, db)
 
-		err := chain.SaveBlock(ctx, 1, []Tx{tx1})
+		err := chain.SaveBlock(ctx, 1, []Tx{tx2})
 		require.NoError(t, err)
-		err = chain.SaveBlock(ctx, 1, []Tx{tx1})
+		err = chain.SaveBlock(ctx, 1, []Tx{tx2})
 		require.NoError(t, err)
 
 		row := db.QueryRow(`SELECT count(*) FROM block`)
@@ -92,6 +139,16 @@ func TestChain_SaveBlock(t *testing.T) {
 		err = row.Scan(&count)
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
+
+		row = db.QueryRow(`SELECT count(*) FROM tendermint_events`)
+		err = row.Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
+
+		row = db.QueryRow(`SELECT count(*) FROM tendermint_event_attrs`)
+		err = row.Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 3, count)
 	})
 
 	t.Run("zero state", func(t *testing.T) {
@@ -111,6 +168,16 @@ func TestChain_SaveBlock(t *testing.T) {
 
 		var count int
 		row = db.QueryRow(`SELECT count(*) FROM tx`)
+		err = row.Scan(&count)
+		require.NoError(t, err)
+		require.Zero(t, count)
+
+		row = db.QueryRow(`SELECT count(*) FROM tendermint_events`)
+		err = row.Scan(&count)
+		require.NoError(t, err)
+		require.Zero(t, count)
+
+		row = db.QueryRow(`SELECT count(*) FROM tendermint_event_attrs`)
 		err = row.Scan(&count)
 		require.NoError(t, err)
 		require.Zero(t, count)

--- a/internal/blockdb/chain_test.go
+++ b/internal/blockdb/chain_test.go
@@ -25,8 +25,8 @@ func TestChain_SaveBlock(t *testing.T) {
 
 	var (
 		ctx = context.Background()
-		tx1 = []byte(`{"test":0}`)
-		tx2 = []byte(`{"test":1}`)
+		tx1 = Tx{Data: []byte(`{"test":0}`)}
+		tx2 = Tx{Data: []byte(`{"test":1}`)}
 	)
 
 	t.Run("happy path", func(t *testing.T) {
@@ -35,7 +35,7 @@ func TestChain_SaveBlock(t *testing.T) {
 
 		chain := validChain(t, db)
 
-		err := chain.SaveBlock(ctx, 5, [][]byte{tx1, tx2})
+		err := chain.SaveBlock(ctx, 5, []Tx{tx1, tx2})
 		require.NoError(t, err)
 
 		row := db.QueryRow(`SELECT height, fk_chain_id, created_at FROM block LIMIT 1`)
@@ -77,9 +77,9 @@ func TestChain_SaveBlock(t *testing.T) {
 
 		chain := validChain(t, db)
 
-		err := chain.SaveBlock(ctx, 1, [][]byte{tx1})
+		err := chain.SaveBlock(ctx, 1, []Tx{tx1})
 		require.NoError(t, err)
-		err = chain.SaveBlock(ctx, 1, [][]byte{tx1})
+		err = chain.SaveBlock(ctx, 1, []Tx{tx1})
 		require.NoError(t, err)
 
 		row := db.QueryRow(`SELECT count(*) FROM block`)

--- a/internal/blockdb/collect.go
+++ b/internal/blockdb/collect.go
@@ -8,15 +8,34 @@ import (
 	"go.uber.org/zap"
 )
 
+type Tx struct {
+	// For Tendermint transactions, this should be encoded as JSON.
+	// Otherwise, this should be a human-readable format if possible.
+	Data []byte
+
+	// Events associated with the transaction, if applicable.
+	Events []Event
+}
+
+// Event is an alternative representation of tendermint/abci/types.Event,
+// so that the blockdb package does not depend directly on tendermint.
+type Event struct {
+	Type       string
+	Attributes []EventAttribute
+}
+
+type EventAttribute struct {
+	Key, Value string
+}
+
 // TxFinder finds transactions given block at height.
 type TxFinder interface {
-	// FindTxs transactions should be in a human-readable format, preferably json.
-	FindTxs(ctx context.Context, height uint64) ([][]byte, error)
+	FindTxs(ctx context.Context, height uint64) ([]Tx, error)
 }
 
 // BlockSaver saves transactions for block at height.
 type BlockSaver interface {
-	SaveBlock(ctx context.Context, height uint64, txs [][]byte) error
+	SaveBlock(ctx context.Context, height uint64, txs []Tx) error
 }
 
 // Collector saves block transactions at regular intervals.

--- a/internal/blockdb/collect.go
+++ b/internal/blockdb/collect.go
@@ -22,6 +22,11 @@ type Tx struct {
 type Event struct {
 	Type       string
 	Attributes []EventAttribute
+
+	// Notably, not including the Index field from the tendermint event.
+	// The ABCI docs state:
+	//
+	// "The index flag notifies the Tendermint indexer to index the attribute. The value of the index flag is non-deterministic and may vary across different nodes in the network."
 }
 
 type EventAttribute struct {

--- a/internal/blockdb/collect_test.go
+++ b/internal/blockdb/collect_test.go
@@ -13,15 +13,15 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type mockTxFinder func(ctx context.Context, height uint64) ([][]byte, error)
+type mockTxFinder func(ctx context.Context, height uint64) ([]Tx, error)
 
-func (f mockTxFinder) FindTxs(ctx context.Context, height uint64) ([][]byte, error) {
+func (f mockTxFinder) FindTxs(ctx context.Context, height uint64) ([]Tx, error) {
 	return f(ctx, height)
 }
 
-type mockBlockSaver func(ctx context.Context, height uint64, txs [][]byte) error
+type mockBlockSaver func(ctx context.Context, height uint64, txs []Tx) error
 
-func (f mockBlockSaver) SaveBlock(ctx context.Context, height uint64, txs [][]byte) error {
+func (f mockBlockSaver) SaveBlock(ctx context.Context, height uint64, txs []Tx) error {
 	return f(ctx, height, txs)
 }
 
@@ -29,7 +29,7 @@ func TestCollector_Collect(t *testing.T) {
 	nopLog := zap.NewNop()
 
 	t.Run("happy path", func(t *testing.T) {
-		finder := mockTxFinder(func(ctx context.Context, height uint64) ([][]byte, error) {
+		finder := mockTxFinder(func(ctx context.Context, height uint64) ([]Tx, error) {
 			if height == 0 {
 				panic("zero height")
 			}
@@ -40,16 +40,16 @@ func TestCollector_Collect(t *testing.T) {
 				if height > 3 {
 					return nil, nil
 				}
-				return [][]byte{[]byte(strconv.FormatUint(height, 10))}, nil
+				return []Tx{{Data: []byte(strconv.FormatUint(height, 10))}}, nil
 			}
 		})
 
 		var (
 			currentHeight int64
 			savedHeights  []int
-			savedTxs      [][][]byte
+			savedTxs      [][]Tx
 		)
-		saver := mockBlockSaver(func(ctx context.Context, height uint64, txs [][]byte) error {
+		saver := mockBlockSaver(func(ctx context.Context, height uint64, txs []Tx) error {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -79,21 +79,21 @@ func TestCollector_Collect(t *testing.T) {
 
 		require.NoError(t, eg.Wait())
 		require.Equal(t, []int{1, 2, 3}, savedHeights[:3])
-		require.Equal(t, "1", string(savedTxs[0][0]))
-		require.Equal(t, "2", string(savedTxs[1][0]))
-		require.Equal(t, "3", string(savedTxs[2][0]))
+		require.Equal(t, "1", string(savedTxs[0][0].Data))
+		require.Equal(t, "2", string(savedTxs[1][0].Data))
+		require.Equal(t, "3", string(savedTxs[2][0].Data))
 	})
 
 	t.Run("find error", func(t *testing.T) {
 		ch := make(chan int)
-		finder := mockTxFinder(func(ctx context.Context, height uint64) ([][]byte, error) {
+		finder := mockTxFinder(func(ctx context.Context, height uint64) ([]Tx, error) {
 			defer func() { ch <- int(height) }()
 			if height == 1 {
 				return nil, nil
 			}
 			return nil, errors.New("boom")
 		})
-		saver := mockBlockSaver(func(ctx context.Context, height uint64, txs [][]byte) error { return nil })
+		saver := mockBlockSaver(func(ctx context.Context, height uint64, txs []Tx) error { return nil })
 
 		collector := NewCollector(nopLog, finder, saver, time.Nanosecond)
 		go collector.Collect(context.Background())
@@ -105,11 +105,11 @@ func TestCollector_Collect(t *testing.T) {
 
 	t.Run("save error", func(t *testing.T) {
 		ch := make(chan int)
-		finder := mockTxFinder(func(ctx context.Context, height uint64) ([][]byte, error) {
+		finder := mockTxFinder(func(ctx context.Context, height uint64) ([]Tx, error) {
 			defer func() { ch <- int(height) }()
 			return nil, nil
 		})
-		saver := mockBlockSaver(func(ctx context.Context, height uint64, txs [][]byte) error {
+		saver := mockBlockSaver(func(ctx context.Context, height uint64, txs []Tx) error {
 			if height == 1 {
 				return nil
 			}

--- a/internal/blockdb/migrate.go
+++ b/internal/blockdb/migrate.go
@@ -91,6 +91,27 @@ ON CONFLICT(git_sha) DO UPDATE SET git_sha=git_sha`, nowRFC3339(), gitSha)
 		return fmt.Errorf("alter table chain add chain_type: %w", err)
 	}
 
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS tendermint_events (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    type TEXT NOT NULL CHECK (length(type) > 0),
+    fk_tx_id INTEGER,
+    FOREIGN KEY(fk_tx_id) REFERENCES tx(id) ON DELETE CASCADE
+)`)
+	if err != nil {
+		return fmt.Errorf("create table tendermint_events: %w", err)
+	}
+
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS tendermint_event_attrs (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    key TEXT NOT NULL CHECK (length(key) > 0),
+    value TEXT NOT NULL CHECK (length(value) > 0),
+    fk_event_id INTEGER,
+    FOREIGN KEY(fk_event_id) REFERENCES tendermint_events(id) ON DELETE CASCADE
+)`)
+	if err != nil {
+		return fmt.Errorf("create table tendermint_events: %w", err)
+	}
+
 	// Creating views should be last migration step.
 	// Error already wrapped.
 	return upsertViews(db)

--- a/internal/blockdb/query_test.go
+++ b/internal/blockdb/query_test.go
@@ -45,8 +45,8 @@ func TestQuery_RecentTestCases(t *testing.T) {
 		require.NoError(t, err)
 		c, err := tc.AddChain(ctx, "chain-b", "cosmos")
 		require.NoError(t, err)
-		require.NoError(t, c.SaveBlock(ctx, 10, [][]byte{[]byte("tx1"), []byte("tx2")}))
-		require.NoError(t, c.SaveBlock(ctx, 11, [][]byte{[]byte("tx3")}))
+		require.NoError(t, c.SaveBlock(ctx, 10, []Tx{{Data: []byte("tx1")}, {Data: []byte("tx2")}}))
+		require.NoError(t, c.SaveBlock(ctx, 11, []Tx{{Data: []byte("tx3")}}))
 
 		_, err = tc.AddChain(ctx, "chain-a", "cosmos")
 		require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestQuery_CosmosMessages(t *testing.T) {
 
 	for i, tx := range txs {
 		require.NotEmpty(t, tx.Raw)
-		err = chain.SaveBlock(ctx, uint64(i+1), [][]byte{[]byte(tx.Raw)})
+		err = chain.SaveBlock(ctx, uint64(i+1), []Tx{{Data: []byte(tx.Raw)}})
 		require.NoError(t, err)
 	}
 
@@ -183,8 +183,8 @@ func TestQuery_Transactions(t *testing.T) {
 		chain, err := tc.AddChain(ctx, "chain-a", "cosmos")
 		require.NoError(t, err)
 
-		require.NoError(t, chain.SaveBlock(ctx, 12, [][]byte{[]byte(`1`)}))
-		require.NoError(t, chain.SaveBlock(ctx, 14, [][]byte{[]byte(`2`), []byte(`3`)}))
+		require.NoError(t, chain.SaveBlock(ctx, 12, []Tx{{Data: []byte(`1`)}}))
+		require.NoError(t, chain.SaveBlock(ctx, 14, []Tx{{Data: []byte(`2`)}, {Data: []byte(`3`)}}))
 
 		results, err := NewQuery(db).Transactions(ctx, chain.id)
 		require.NoError(t, err)

--- a/internal/blockdb/views_test.go
+++ b/internal/blockdb/views_test.go
@@ -24,12 +24,12 @@ func TestTxFlattenedView(t *testing.T) {
 	require.NoError(t, err)
 
 	beforeBlocksCreated := time.Now().UTC().Format(time.RFC3339)
-	require.NoError(t, chain.SaveBlock(ctx, 1, [][]byte{
-		[]byte("tx1.0"),
+	require.NoError(t, chain.SaveBlock(ctx, 1, []Tx{
+		{Data: []byte("tx1.0")},
 	}))
-	require.NoError(t, chain.SaveBlock(ctx, 2, [][]byte{
-		[]byte("tx2.0"),
-		[]byte("tx2.1"),
+	require.NoError(t, chain.SaveBlock(ctx, 2, []Tx{
+		{Data: []byte("tx2.0")},
+		{Data: []byte("tx2.1")},
 	}))
 	afterBlocksCreated := time.Now().UTC().Format(time.RFC3339)
 


### PR DESCRIPTION
Separated into two commits; the first translates the previous `[]byte` for transactions into the new `Tx` structure and adds a field for `Events`, and then the second populates the `Events` field.

The `Event` has a `Type` string and many key-value pair `Attributes`, and any transaction may have many events; so this change added one table for the event and another table for the attributes. IOW transactions have many events and events have many attributes.