### PR TITLE
Add block waits in message view tests

### DIFF
--- a/internal/blockdb/messages_view_test.go
+++ b/internal/blockdb/messages_view_test.go
@@ -115,6 +115,10 @@ WHERE type = "/ibc.core.client.v1.MsgCreateClient" AND chain_id = ?;`
 
 		// Next, create the connections.
 		require.NoError(t, r.CreateConnections(ctx, eRep, pathName))
+
+		// Wait for another block before retrieving the connections and querying for them.
+		require.NoError(t, test.WaitForBlocks(ctx, 1, gaia0, gaia1))
+
 		conns, err := r.GetConnections(ctx, eRep, gaia0ChainID)
 		require.NoError(t, err)
 
@@ -179,6 +183,9 @@ WHERE type = "/ibc.core.connection.v1.MsgConnectionOpenConfirm" AND chain_id = ?
 			Order:          "unordered",
 			Version:        "ics20-1",
 		}))
+
+		// Wait for another block before retrieving the channels and querying for them.
+		require.NoError(t, test.WaitForBlocks(ctx, 1, gaia0, gaia1))
 
 		channels, err := r.GetChannels(ctx, eRep, gaia0ChainID)
 		require.NoError(t, err)


### PR DESCRIPTION
These two spots had somewhat frequent failures due to the following
queries returning no rows, so wait for one block in order to give the
block collector more time to detect the new blocks, before attempting to
execute the queries.
