### PR TITLE
Add (*Interchain).Close method

### DIFF
--- a/conformance/flush.go
+++ b/conformance/flush.go
@@ -58,6 +58,7 @@ func TestRelayerFlushing(t *testing.T, cf ibctest.ChainFactory, rf ibctest.Relay
 		Pool:      pool,
 		NetworkID: network,
 	}))
+	defer ic.Close()
 
 	// Get faucet address on destination chain for ibc transfer.
 	c1FaucetAddrBytes, err := c1.GetAddress(ctx, ibctest.FaucetAccountKeyName)

--- a/conformance/relayersetup.go
+++ b/conformance/relayersetup.go
@@ -61,6 +61,7 @@ func TestRelayerSetup(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerF
 		// since that is what we are about to test.
 		SkipPathCreation: true,
 	}))
+	defer ic.Close()
 
 	// Now handle each creation step as a subtest in sequence.
 	// After each subtest, check t.Failed, which will be true if a subtest failed,

--- a/interchain_test.go
+++ b/interchain_test.go
@@ -61,6 +61,7 @@ func TestInterchain_DuplicateChain(t *testing.T) {
 
 		SkipPathCreation: true,
 	}))
+	_ = ic.Close()
 }
 
 // An external package that imports ibctest may not provide a GitSha when they provide a BlockDatabaseFile.
@@ -99,6 +100,7 @@ func TestInterchain_OmitGitSHA(t *testing.T) {
 
 		BlockDatabaseFile: ":memory:",
 	}))
+	_ = ic.Close()
 }
 
 func TestInterchain_ConflictRejection(t *testing.T) {

--- a/internal/blockdb/collect_test.go
+++ b/internal/blockdb/collect_test.go
@@ -3,7 +3,9 @@ package blockdb
 import (
 	"context"
 	"errors"
+	"runtime"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -62,6 +64,7 @@ func TestCollector_Collect(t *testing.T) {
 		})
 
 		collector := NewCollector(nopLog, finder, saver, time.Nanosecond)
+		defer collector.Stop()
 
 		ctx, cancel := context.WithCancel(context.Background())
 		var eg errgroup.Group
@@ -96,6 +99,7 @@ func TestCollector_Collect(t *testing.T) {
 		saver := mockBlockSaver(func(ctx context.Context, height uint64, txs [][]byte) error { return nil })
 
 		collector := NewCollector(nopLog, finder, saver, time.Nanosecond)
+		defer collector.Stop()
 		go collector.Collect(context.Background())
 
 		require.Equal(t, 1, <-ch)
@@ -117,10 +121,55 @@ func TestCollector_Collect(t *testing.T) {
 		})
 
 		collector := NewCollector(nopLog, finder, saver, time.Nanosecond)
+		defer collector.Stop()
 		go collector.Collect(context.Background())
 
 		require.Equal(t, 1, <-ch)
 		require.Equal(t, 2, <-ch)
 		require.Equal(t, 2, <-ch) // assert height stops advancing
 	})
+}
+
+func TestCollector_Stop(t *testing.T) {
+	// Synchronization control to allow test to progress without a data race.
+	// Begins locked, unlocks from the finder, and the test blocks trying to re-lock it.
+	var foundMu sync.Mutex
+	foundMu.Lock()
+
+	// Ensures the finder only unlocks the mutex once.
+	var foundOnce sync.Once
+
+	finder := mockTxFinder(func(ctx context.Context, height uint64) ([][]byte, error) {
+		foundOnce.Do(func() {
+			foundMu.Unlock()
+		})
+		return nil, nil
+	})
+	saver := mockBlockSaver(func(ctx context.Context, height uint64, txs [][]byte) error { return nil })
+
+	c := NewCollector(zap.NewNop(), finder, saver, time.Millisecond)
+	defer c.Stop() // Will be stopped explicitly in a few lines, but defer anyway for cleanup just in case.
+
+	n := runtime.NumGoroutine()
+	go c.Collect(context.Background())
+
+	// Block until the finder was called at least once.
+	foundMu.Lock()
+
+	// At least one goroutine was created.
+	require.Greater(t, runtime.NumGoroutine(), n)
+
+	c.Stop()
+
+	// require.Eventually would be nice here, but that starts its own goroutine,
+	// which defeats the purpose of this test.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() == n {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	require.Failf(t, "goroutine count did not drop after stopping collector", "want %d, got %d", n, runtime.NumGoroutine())
 }

--- a/test_setup.go
+++ b/test_setup.go
@@ -53,7 +53,6 @@ func DockerSetup(t *testing.T) (*dockertest.Pool, string) {
 	})
 	if err != nil {
 		t.Fatalf("failed to create docker network: %v", err)
-
 	}
 
 	return pool, network.ID
@@ -106,6 +105,9 @@ func StartChainPairAndRelayer(
 	}); err != nil {
 		return errResponse(err)
 	}
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
 
 	channels, err := relayerImpl.GetChannels(ctx, eRep, srcChain.Config().ChainID)
 	if err != nil {


### PR DESCRIPTION
This cleans up any created resources from Build(). The actual docker
containers are torn down via t.Cleanup, but the block collector
goroutine associated with the chainSet is now destroyed upon call to
Close, which reduces the number of goroutines present in a stack trace
due to a panic, test timeout, or deliberate SIGQUIT.

This PR is split into two commits for easier reading if so desired.