### PR TITLE
Support concurrent reads/writes against blockdb

### DIFF
--- a/internal/blockdb/messages_view_test.go
+++ b/internal/blockdb/messages_view_test.go
@@ -78,6 +78,11 @@ func TestMessagesView(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
+	// Copy the busy timeout from the migration.
+	// The journal_mode pragma should be persisted on disk, so we should not need to set that here.
+	_, err = db.Exec(`PRAGMA busy_timeout = 3000`)
+	require.NoError(t, err)
+
 	var count int
 	row := db.QueryRow(`SELECT COUNT(*) FROM v_cosmos_messages`)
 	require.NoError(t, row.Scan(&count))

--- a/internal/blockdb/messages_view_test.go
+++ b/internal/blockdb/messages_view_test.go
@@ -121,8 +121,8 @@ WHERE type = "/ibc.core.client.v1.MsgCreateClient" AND chain_id = ?;`
 		// Next, create the connections.
 		require.NoError(t, r.CreateConnections(ctx, eRep, pathName))
 
-		// Wait for two more blocks before retrieving the connections and querying for them.
-		require.NoError(t, test.WaitForBlocks(ctx, 2, gaia0, gaia1))
+		// Wait for another block before retrieving the connections and querying for them.
+		require.NoError(t, test.WaitForBlocks(ctx, 1, gaia0, gaia1))
 
 		conns, err := r.GetConnections(ctx, eRep, gaia0ChainID)
 		require.NoError(t, err)
@@ -189,8 +189,8 @@ WHERE type = "/ibc.core.connection.v1.MsgConnectionOpenConfirm" AND chain_id = ?
 			Version:        "ics20-1",
 		}))
 
-		// Wait for two more blocks before retrieving the channels and querying for them.
-		require.NoError(t, test.WaitForBlocks(ctx, 2, gaia0, gaia1))
+		// Wait for another block before retrieving the channels and querying for them.
+		require.NoError(t, test.WaitForBlocks(ctx, 1, gaia0, gaia1))
 
 		channels, err := r.GetChannels(ctx, eRep, gaia0ChainID)
 		require.NoError(t, err)

--- a/internal/blockdb/messages_view_test.go
+++ b/internal/blockdb/messages_view_test.go
@@ -121,8 +121,8 @@ WHERE type = "/ibc.core.client.v1.MsgCreateClient" AND chain_id = ?;`
 		// Next, create the connections.
 		require.NoError(t, r.CreateConnections(ctx, eRep, pathName))
 
-		// Wait for another block before retrieving the connections and querying for them.
-		require.NoError(t, test.WaitForBlocks(ctx, 1, gaia0, gaia1))
+		// Wait for two more blocks before retrieving the connections and querying for them.
+		require.NoError(t, test.WaitForBlocks(ctx, 2, gaia0, gaia1))
 
 		conns, err := r.GetConnections(ctx, eRep, gaia0ChainID)
 		require.NoError(t, err)
@@ -189,8 +189,8 @@ WHERE type = "/ibc.core.connection.v1.MsgConnectionOpenConfirm" AND chain_id = ?
 			Version:        "ics20-1",
 		}))
 
-		// Wait for another block before retrieving the channels and querying for them.
-		require.NoError(t, test.WaitForBlocks(ctx, 1, gaia0, gaia1))
+		// Wait for two more blocks before retrieving the channels and querying for them.
+		require.NoError(t, test.WaitForBlocks(ctx, 2, gaia0, gaia1))
 
 		channels, err := r.GetChannels(ctx, eRep, gaia0ChainID)
 		require.NoError(t, err)

--- a/internal/blockdb/migrate.go
+++ b/internal/blockdb/migrate.go
@@ -57,7 +57,11 @@ func Migrate(db *sql.DB, gitSha string) error {
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		// If commit succeeded, rollback will return nil;
+		// if a step failed, the returned error is more meaningful.
+		_ = tx.Rollback()
+	}()
 
 	_, err = tx.Exec(`CREATE TABLE IF NOT EXISTS schema_version(
     id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,

--- a/internal/blockdb/migrate.go
+++ b/internal/blockdb/migrate.go
@@ -25,12 +25,13 @@ import (
 func Migrate(db *sql.DB, gitSha string) error {
 	// If a timeout is encountered, sleep and try again,
 	// up until the provided number of milliseconds.
+	// A 3000ms timeout worked fine on my workstation but failed the concurrency test on CI.
 	//
 	// Setting this makes it practical to have multiple test instances
 	// writing to the same database file.
 	//
 	// https://www.sqlite.org/pragma.html#pragma_busy_timeout
-	_, err := db.Exec(`PRAGMA busy_timeout = 3000`)
+	_, err := db.Exec(`PRAGMA busy_timeout = 4000`)
 	if err != nil {
 		return fmt.Errorf("pragma busy_timeout: %w", err)
 	}

--- a/internal/blockdb/sql_test.go
+++ b/internal/blockdb/sql_test.go
@@ -82,11 +82,13 @@ func TestDB_Concurrency(t *testing.T) {
 				if err != nil {
 					return fmt.Errorf("writer %d failed to create test case %d/%d: %w", i, j+1, nTestCases, err)
 				}
+				time.Sleep(time.Millisecond)
 
 				_, err = tc.AddChain(egCtx, fmt.Sprintf("chain-%d-%d", i, j), "cosmos")
 				if err != nil {
 					return fmt.Errorf("writer %d failed to add chain to test case %d/%d: %w", i, j+1, nTestCases, err)
 				}
+				time.Sleep(time.Millisecond)
 			}
 
 			return nil

--- a/internal/blockdb/sql_test.go
+++ b/internal/blockdb/sql_test.go
@@ -3,12 +3,14 @@ package blockdb
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 func emptyDB() *sql.DB {
@@ -33,4 +35,112 @@ func TestConnectDB(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
+}
+
+// Test that multiple writers and readers against the same underlying file
+// do not fail due to a "database is locked" error.
+func TestDB_Concurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping due to short mode")
+	}
+
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbPath := filepath.Join(t.TempDir(), "concurrent.db")
+
+	// Block all writers until this channel is closed.
+	beginWrites := make(chan struct{})
+
+	const nWriters = 4
+	const nTestCases = 500
+	const nQueriers = 2
+	const sha = "abc123"
+
+	// Dedicated errgroup for the writers,
+	// and a shared context so all fail if one fails.
+	egWrites, egCtx := errgroup.WithContext(ctx)
+	for i := 0; i < nWriters; i++ {
+		i := i
+
+		// Connecting to the database in the main goroutine
+		// because concurrently connecting to the same database
+		// causes a data race inside sqlite.
+		db, err := ConnectDB(ctx, dbPath)
+		require.NoErrorf(t, err, "failed to connect to db for writer %d: %v", i, err)
+		defer db.Close()
+		require.NoError(t, Migrate(db, sha))
+
+		egWrites.Go(func() error {
+			// Block until this channel is closed.
+			<-beginWrites
+
+			for j := 0; j < nTestCases; j++ {
+				tc, err := CreateTestCase(egCtx, db, fmt.Sprintf("test-%d-%d", i, j), sha)
+				if err != nil {
+					return fmt.Errorf("writer %d failed to create test case %d/%d: %w", i, j+1, nTestCases, err)
+				}
+
+				_, err = tc.AddChain(egCtx, fmt.Sprintf("chain-%d-%d", i, j), "cosmos")
+				if err != nil {
+					return fmt.Errorf("writer %d failed to add chain to test case %d/%d: %w", i, j+1, nTestCases, err)
+				}
+			}
+
+			return nil
+		})
+	}
+
+	// Separate errgroup for the queriers.
+	var egQueries errgroup.Group
+	for i := 0; i < nQueriers; i++ {
+		i := i
+
+		db, err := ConnectDB(ctx, dbPath)
+		require.NoErrorf(t, err, "failed to connect to db for querier %d: %v", i, err)
+		defer db.Close()
+		require.NoError(t, Migrate(db, sha))
+
+		egQueries.Go(func() error {
+			// No need to synchronize here; just begin querying.
+			q := NewQuery(db)
+
+			for {
+				if ctx.Err() != nil {
+					// Context was canceled; querying is finished.
+					return nil
+				}
+
+				// Deliberately using context.Background() here so that
+				// canceling the writers does not cause an "interrupted" error
+				// when querying the recent test cases.
+				// (This must be an sqlite implementation detail, as that error
+				// is distinct from context.Canceled.)
+				_, err := q.RecentTestCases(context.Background(), nTestCases*nWriters)
+				if err != nil {
+					return fmt.Errorf("error in querier %d retrieving test cases: %w", i, err)
+				}
+			}
+		})
+	}
+
+	// Signal that writes can begin, then wait for them to finish.
+	close(beginWrites)
+	require.NoError(t, egWrites.Wait())
+
+	// Signal that queries should stop, then wait for them to finish.
+	cancel()
+	require.NoError(t, egQueries.Wait())
+
+	// Final assertions against written number of test cases.
+	db, err := ConnectDB(context.Background(), dbPath)
+	require.NoErrorf(t, err, "failed to connect to db for final assertion")
+	defer db.Close()
+
+	tcs, err := NewQuery(db).RecentTestCases(context.Background(), nTestCases*nWriters)
+	require.NoError(t, err, "failed to collect recent test cases")
+
+	require.Len(t, tcs, nTestCases*nWriters, "incorrect count on final written test cases")
 }


### PR DESCRIPTION
This sets two pragmas on the database, which requires that callers do
run Migrate before accessing the database.

Now, it should be trivial to configure all tests to use the same
database file on disk and concurrently read and write without
encountering "database is locked" errors.

Closes #138.