### PR TITLE
docs: Add clarity for conformance tests

### DIFF
--- a/conformance/test.go
+++ b/conformance/test.go
@@ -251,9 +251,13 @@ func Test(t *testing.T, cfs []ibctest.ChainFactory, rfs []ibctest.RelayerFactory
 }
 
 // TestChainPair runs the conformance tests for two chains and one relayer.
-// This function is exported in case there is a third party that needs to run this test
-// without the parallel subtests structure from Test,
-// but the stability of this API and even the existence of this function is not guaranteed.
+// This test asserts bidirectional behavior between both chains.
+//
+// Given 2 chains, Chain A and Chain B, this test asserts:
+// 1. Successful IBC transfer from A -> B and B -> A.
+// 2. Proper handling of no timeout from A -> B and B -> A.
+// 3. Proper handling of height timeout from A -> B and B -> A.
+// 4. Proper handling of timestamp timeout from A -> B and B -> A.
 func TestChainPair(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory, rep *testreporter.Reporter) {
 	pool, network := ibctest.DockerSetup(t)
 


### PR DESCRIPTION
A baby step towards https://github.com/strangelove-ventures/ibctest/issues/152

I originally wanted to rename this function from `TestChainPair` to `TestIBCTransfer`. However, I held off because I'm not sure how this function will evolve. It may be more efficient (like test setup) to keep adding scenarios to `TestChainPair`.

I like the pattern where the relayer has 2 separate conformance tests for setup and flush. 

I would love to constrain conformance tests to 2-chain-1-relayer, but that may not be possible for a scenario like packet-forward-middleware. 

In the above case where, for instance, 3 chains are needed, I advocate for a separate conformance test like `TestPacketForwardMiddleware` that requires 3 chains and 1 relayer. But it may cause issue when running ibctest conformance tests periodically to produce a conformance report.