### PR TITLE
Fix YAML multiline syntax

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
 
       # cleanup environment on self-hosted test runner
       - name: clean
-        run: -|
+        run: |-
           rm -rf ~/.ibctest
 
       # run tests


### PR DESCRIPTION
The "clean" step had this error:

     line 1: -: command not found

because it was trying to pipe the output of "-" into rm.

Thanks to https://yaml-multiline.info/ for supplying a clear explanation
of the correct syntax.
