### PR TITLE
Expose relayer account information

### DIFF
--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -24,6 +24,9 @@ type Relayer interface {
 	// generate a new key
 	AddKey(ctx context.Context, rep RelayerExecReporter, chainID, keyName string) (RelayerWallet, error)
 
+	// GetWallet returns a RelayerWallet for that relayer on the given chain and a boolean indicating if it was found.
+	GetWallet(chainID string) (RelayerWallet, bool)
+
 	// add relayer configuration for a chain
 	AddChainConfiguration(ctx context.Context, rep RelayerExecReporter, chainConfig ChainConfig, keyName, rpcAddr, grpcAddr string) error
 

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -223,6 +223,10 @@ func (commander) ParseAddKeyOutput(stdout, stderr string) (ibc.RelayerWallet, er
 	return wallet, err
 }
 
+func (commander) ParseRestoreKeyOutput(stdout, stderr string) string {
+	return strings.Replace(stdout, "\n", "", 1)
+}
+
 func (c commander) ParseGetChannelsOutput(stdout, stderr string) ([]ibc.ChannelOutput, error) {
 	var channels []ibc.ChannelOutput
 	channelSplit := strings.Split(stdout, "\n")


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR exposes relayer account information through the `Relayer` interface.

## Checklist

- [X] I have made sure the upstream branch for this PR is correct
- [X] I have made sure this PR is ready to merge
- [X] I have made sure that I have assigned reviewers related to this project

## Changes

- [X] Added `ParseRestoreKeyOutput` to `RelayerCommander` interface.
- [X] Added `GetWallet` to `Relayer` interface.
- [X] Added test to verify wallets are accessible.
- [X] Added mapping of chainID to wallet in the `DockerRelayer` type.

closes #159


