### PR TITLE
Remove non-empty constraint from attr values

### DIFF
--- a/internal/blockdb/migrate.go
+++ b/internal/blockdb/migrate.go
@@ -104,7 +104,7 @@ ON CONFLICT(git_sha) DO UPDATE SET git_sha=git_sha`, nowRFC3339(), gitSha)
 	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS tendermint_event_attr (
     id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     key TEXT NOT NULL CHECK (length(key) > 0),
-    value TEXT NOT NULL CHECK (length(value) > 0),
+    value TEXT NOT NULL,
     fk_event_id INTEGER,
     FOREIGN KEY(fk_event_id) REFERENCES tendermint_event(id) ON DELETE CASCADE
 )`)


### PR DESCRIPTION
Some events do have an empty value, such as the connection_open_init
type, at least sometimes when the key is counterparty_connection_id.
Disallowing this caused the collector to be stuck in a loop on repeated
failures to save the attribute.

This should fix the consistent failure on the messages view test.