### PR TITLE
Add support for declaring the channel configuration options

### DIFF
--- a/conformance/flush.go
+++ b/conformance/flush.go
@@ -53,10 +53,11 @@ func TestRelayerFlushing(t *testing.T, cf ibctest.ChainFactory, rf ibctest.Relay
 	eRep := rep.RelayerExecReporter(t)
 
 	req.NoError(ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
-		TestName:  t.Name(),
-		HomeDir:   home,
-		Pool:      pool,
-		NetworkID: network,
+		TestName:          t.Name(),
+		HomeDir:           home,
+		Pool:              pool,
+		NetworkID:         network,
+		CreateChannelOpts: ibc.DefaultChannelOpts(),
 	}))
 	defer ic.Close()
 

--- a/conformance/relayersetup.go
+++ b/conformance/relayersetup.go
@@ -134,7 +134,7 @@ func TestRelayerSetup(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerF
 		req.NoError(r.CreateChannel(ctx, eRep, pathName, ibc.CreateChannelOptions{
 			SourcePortName: "transfer",
 			DestPortName:   "transfer",
-			Order:          "unordered",
+			Order:          ibc.Unordered,
 			Version:        "ics20-1",
 		}))
 

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -2,6 +2,7 @@ package ibc
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -90,9 +91,32 @@ type CreateChannelOptions struct {
 type Order int
 
 const (
-	Ordered Order = iota
+	Invalid Order = iota
+	Ordered
 	Unordered
 )
+
+// String returns the lowercase string representation of the Order.
+func (o Order) String() string {
+	switch o {
+	case Unordered:
+		return "unordered"
+	case Ordered:
+		return "ordered"
+	default:
+		return "invalid"
+	}
+}
+
+var ErrInvalidOrderType = fmt.Errorf("the specified channel order is invalid")
+
+// Validate checks that the Order type is a valid value.
+func (o Order) Validate() error {
+	if o == Ordered || o == Unordered {
+		return nil
+	}
+	return ErrInvalidOrderType
+}
 
 // DefaultChannelOpts returns the default settings for creating an ics20 fungible token transfer channel.
 func DefaultChannelOpts() CreateChannelOptions {
@@ -109,7 +133,7 @@ func (opts CreateChannelOptions) IsFullyConfigured() bool {
 	return opts.SourcePortName != "" &&
 		opts.DestPortName != "" &&
 		opts.Version != "" &&
-		opts.Order == Ordered || opts.Order == Unordered
+		opts.Order != Invalid
 }
 
 // ExecReporter is the interface of a narrow type returned by testreporter.RelayerExecReporter.

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -81,19 +81,35 @@ type CreateChannelOptions struct {
 	SourcePortName string
 	DestPortName   string
 
-	Order string
+	Order Order
 
 	Version string
 }
 
-// DefaultChannelOpts returns the default settings for creating a ics20 fungible token transfer channel.
+// Order represents an IBC channel's order.
+type Order int
+
+const (
+	Ordered Order = iota
+	Unordered
+)
+
+// DefaultChannelOpts returns the default settings for creating an ics20 fungible token transfer channel.
 func DefaultChannelOpts() CreateChannelOptions {
 	return CreateChannelOptions{
 		SourcePortName: "transfer",
 		DestPortName:   "transfer",
-		Order:          "unordered",
+		Order:          Unordered,
 		Version:        "ics20-1",
 	}
+}
+
+// IsFullyConfigured returns true if all the CreateChannelOption's fields have been specified.
+func (opts CreateChannelOptions) IsFullyConfigured() bool {
+	return opts.SourcePortName != "" &&
+		opts.DestPortName != "" &&
+		opts.Version != "" &&
+		opts.Order == Ordered || opts.Order == Unordered
 }
 
 // ExecReporter is the interface of a narrow type returned by testreporter.RelayerExecReporter.

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -31,7 +31,7 @@ type Relayer interface {
 	GeneratePath(ctx context.Context, rep RelayerExecReporter, srcChainID, dstChainID, pathName string) error
 
 	// setup channels, connections, and clients
-	LinkPath(ctx context.Context, rep RelayerExecReporter, pathName string) error
+	LinkPath(ctx context.Context, rep RelayerExecReporter, pathName string, opts CreateChannelOptions) error
 
 	// update clients, such as after new genesis
 	UpdateClients(ctx context.Context, rep RelayerExecReporter, pathName string) error
@@ -84,6 +84,16 @@ type CreateChannelOptions struct {
 	Order string
 
 	Version string
+}
+
+// DefaultChannelOpts returns the default settings for creating a ics20 fungible token transfer channel.
+func DefaultChannelOpts() CreateChannelOptions {
+	return CreateChannelOptions{
+		SourcePortName: "transfer",
+		DestPortName:   "transfer",
+		Order:          "unordered",
+		Version:        "ics20-1",
+	}
 }
 
 // ExecReporter is the interface of a narrow type returned by testreporter.RelayerExecReporter.

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -91,8 +91,8 @@ type CreateChannelOptions struct {
 	Version string
 }
 
-// defaultChannelOpts returns the default settings for creating an ics20 fungible token transfer channel.
-func defaultChannelOpts() CreateChannelOptions {
+// DefaultChannelOpts returns the default settings for creating an ics20 fungible token transfer channel.
+func DefaultChannelOpts() CreateChannelOptions {
 	return CreateChannelOptions{
 		SourcePortName: "transfer",
 		DestPortName:   "transfer",

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	chanTypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
+	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	ptypes "github.com/cosmos/ibc-go/v3/modules/core/05-port/types"
 	host "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 )
@@ -111,7 +111,7 @@ func (opts CreateChannelOptions) Validate() error {
 	case opts.Version == "":
 		return fmt.Errorf("invalid channel version")
 	case opts.Order.Validate() != nil:
-		return chanTypes.ErrInvalidChannelOrdering
+		return chantypes.ErrInvalidChannelOrdering
 	}
 	return nil
 }
@@ -142,7 +142,7 @@ func (o Order) Validate() error {
 	if o == Ordered || o == Unordered {
 		return nil
 	}
-	return chanTypes.ErrInvalidChannelOrdering
+	return chantypes.ErrInvalidChannelOrdering
 }
 
 // ExecReporter is the interface of a narrow type returned by testreporter.RelayerExecReporter.

--- a/ibc/relayer_test.go
+++ b/ibc/relayer_test.go
@@ -22,7 +22,8 @@ func TestChannelOptsConfigured(t *testing.T) {
 		Order:          3,
 		Version:        "123",
 	}
-	require.False(t, opts.IsFullyConfigured())
+	require.True(t, opts.IsFullyConfigured())
+	require.Equal(t, ErrInvalidOrderType, opts.Order.Validate())
 
 	// Test partial channel opts
 	opts = CreateChannelOptions{

--- a/ibc/relayer_test.go
+++ b/ibc/relayer_test.go
@@ -1,0 +1,34 @@
+package ibc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelOptsConfigured(t *testing.T) {
+	// Test the default channel opts
+	opts := DefaultChannelOpts()
+	require.True(t, opts.IsFullyConfigured())
+
+	// Test empty struct channel opts
+	opts = CreateChannelOptions{}
+	require.False(t, opts.IsFullyConfigured())
+
+	// Test invalid Order type in channel opts
+	opts = CreateChannelOptions{
+		SourcePortName: "transfer",
+		DestPortName:   "transfer",
+		Order:          3,
+		Version:        "123",
+	}
+	require.False(t, opts.IsFullyConfigured())
+
+	// Test partial channel opts
+	opts = CreateChannelOptions{
+		SourcePortName: "",
+		DestPortName:   "",
+		Order:          0,
+	}
+	require.False(t, opts.IsFullyConfigured())
+}

--- a/ibc/relayer_test.go
+++ b/ibc/relayer_test.go
@@ -3,17 +3,18 @@ package ibc
 import (
 	"testing"
 
+	chanTypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestChannelOptsConfigured(t *testing.T) {
 	// Test the default channel opts
-	opts := DefaultChannelOpts()
-	require.True(t, opts.IsFullyConfigured())
+	opts := defaultChannelOpts()
+	require.NoError(t, opts.Validate())
 
 	// Test empty struct channel opts
 	opts = CreateChannelOptions{}
-	require.False(t, opts.IsFullyConfigured())
+	require.Error(t, opts.Validate())
 
 	// Test invalid Order type in channel opts
 	opts = CreateChannelOptions{
@@ -22,8 +23,8 @@ func TestChannelOptsConfigured(t *testing.T) {
 		Order:          3,
 		Version:        "123",
 	}
-	require.True(t, opts.IsFullyConfigured())
-	require.Equal(t, ErrInvalidOrderType, opts.Order.Validate())
+	require.Error(t, opts.Validate())
+	require.Equal(t, chanTypes.ErrInvalidChannelOrdering, opts.Order.Validate())
 
 	// Test partial channel opts
 	opts = CreateChannelOptions{
@@ -31,5 +32,5 @@ func TestChannelOptsConfigured(t *testing.T) {
 		DestPortName:   "",
 		Order:          0,
 	}
-	require.False(t, opts.IsFullyConfigured())
+	require.Error(t, opts.Validate())
 }

--- a/ibc/relayer_test.go
+++ b/ibc/relayer_test.go
@@ -3,7 +3,7 @@ package ibc
 import (
 	"testing"
 
-	chanTypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
+	chantypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +24,7 @@ func TestChannelOptsConfigured(t *testing.T) {
 		Version:        "123",
 	}
 	require.Error(t, opts.Validate())
-	require.Equal(t, chanTypes.ErrInvalidChannelOrdering, opts.Order.Validate())
+	require.Equal(t, chantypes.ErrInvalidChannelOrdering, opts.Order.Validate())
 
 	// Test partial channel opts
 	opts = CreateChannelOptions{

--- a/ibc/relayer_test.go
+++ b/ibc/relayer_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestChannelOptsConfigured(t *testing.T) {
 	// Test the default channel opts
-	opts := defaultChannelOpts()
+	opts := DefaultChannelOpts()
 	require.NoError(t, opts.Validate())
 
 	// Test empty struct channel opts

--- a/interchain.go
+++ b/interchain.go
@@ -219,6 +219,11 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 		return nil
 	}
 
+	// Check that the channel creation options are valid and fully specified.
+	if err := opts.CreateChannelOpts.Validate(); err != nil {
+		return err
+	}
+
 	// For every relayer link, teach the relayer about the link and create the link.
 	for rp, chains := range ic.links {
 		c0 := chains[0]
@@ -228,16 +233,6 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 				"failed to generate path %s on relayer %s between chains %s and %s: %w",
 				rp.Path, rp.Relayer, ic.chains[c0], ic.chains[c1], err,
 			)
-		}
-
-		// If channel creation options are not fully specified, default to the ics20 fungible token transfer channel options.
-		if !opts.CreateChannelOpts.IsFullyConfigured() {
-			opts.CreateChannelOpts = ibc.DefaultChannelOpts()
-		}
-
-		// Check that the channel order type is a valid value.
-		if err := opts.CreateChannelOpts.Order.Validate(); err != nil {
-			return err
 		}
 
 		if err := rp.Relayer.LinkPath(ctx, rep, rp.Path, opts.CreateChannelOpts); err != nil {

--- a/interchain.go
+++ b/interchain.go
@@ -160,6 +160,10 @@ type InterchainBuildOptions struct {
 	// This is useful for tests that need lower-level access to configuring relayers.
 	SkipPathCreation bool
 
+	// If set, these options will be used when creating the channel in the path link step.
+	// If not set, the application will default to the options for creating an ics20 fungible token transfer.
+	CreateChannelOpts ibc.CreateChannelOptions
+
 	// Optional. Git sha for test invocation. Once Go 1.18 supported,
 	// may be deprecated in favor of runtime/debug.ReadBuildInfo.
 	GitSha string
@@ -226,7 +230,11 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 			)
 		}
 
-		if err := rp.Relayer.LinkPath(ctx, rep, rp.Path); err != nil {
+		// If channel creation options are not specified, default to the ics20 fungible token transfer channel options.
+		if (opts.CreateChannelOpts == ibc.CreateChannelOptions{}) {
+			opts.CreateChannelOpts = ibc.DefaultChannelOpts()
+		}
+		if err := rp.Relayer.LinkPath(ctx, rep, rp.Path, opts.CreateChannelOpts); err != nil {
 			return fmt.Errorf(
 				"failed to link path %s on relayer %s between chains %s and %s: %w",
 				rp.Path, rp.Relayer, ic.chains[c0], ic.chains[c1], err,

--- a/interchain.go
+++ b/interchain.go
@@ -230,10 +230,11 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 			)
 		}
 
-		// If channel creation options are not specified, default to the ics20 fungible token transfer channel options.
-		if (opts.CreateChannelOpts == ibc.CreateChannelOptions{}) {
+		// If channel creation options are not fully specified, default to the ics20 fungible token transfer channel options.
+		if !opts.CreateChannelOpts.IsFullyConfigured() {
 			opts.CreateChannelOpts = ibc.DefaultChannelOpts()
 		}
+
 		if err := rp.Relayer.LinkPath(ctx, rep, rp.Path, opts.CreateChannelOpts); err != nil {
 			return fmt.Errorf(
 				"failed to link path %s on relayer %s between chains %s and %s: %w",

--- a/interchain.go
+++ b/interchain.go
@@ -160,7 +160,9 @@ type InterchainBuildOptions struct {
 	// This is useful for tests that need lower-level access to configuring relayers.
 	SkipPathCreation bool
 
-	// These options will be used when creating the channel in the path link step.
+	// If set, these options will be used when creating the channel in the path link step.
+	// If a zero value initialization is used, e.g. CreateChannelOptions{},
+	// then the default values will be used via ibc.DefaultChannelOpts.
 	CreateChannelOpts ibc.CreateChannelOptions
 
 	// Optional. Git sha for test invocation. Once Go 1.18 supported,
@@ -216,6 +218,12 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 	// but still have wallets configured.
 	if opts.SkipPathCreation {
 		return nil
+	}
+
+	// If the user specifies a zero value CreateChannelOptions struct then we fall back to the default
+	// channel options for an ics20 fungible token transfer channel.
+	if opts.CreateChannelOpts == (ibc.CreateChannelOptions{}) {
+		opts.CreateChannelOpts = ibc.DefaultChannelOpts()
 	}
 
 	// Check that the channel creation options are valid and fully specified.

--- a/interchain.go
+++ b/interchain.go
@@ -160,8 +160,7 @@ type InterchainBuildOptions struct {
 	// This is useful for tests that need lower-level access to configuring relayers.
 	SkipPathCreation bool
 
-	// If set, these options will be used when creating the channel in the path link step.
-	// If not set, the application will default to the options for creating an ics20 fungible token transfer.
+	// These options will be used when creating the channel in the path link step.
 	CreateChannelOpts ibc.CreateChannelOptions
 
 	// Optional. Git sha for test invocation. Once Go 1.18 supported,

--- a/interchain.go
+++ b/interchain.go
@@ -235,6 +235,11 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 			opts.CreateChannelOpts = ibc.DefaultChannelOpts()
 		}
 
+		// Check that the channel order type is a valid value.
+		if err := opts.CreateChannelOpts.Order.Validate(); err != nil {
+			return err
+		}
+
 		if err := rp.Relayer.LinkPath(ctx, rep, rp.Path, opts.CreateChannelOpts); err != nil {
 			return fmt.Errorf(
 				"failed to link path %s on relayer %s between chains %s and %s: %w",

--- a/internal/blockdb/messages_view_test.go
+++ b/internal/blockdb/messages_view_test.go
@@ -180,7 +180,7 @@ WHERE type = "/ibc.core.connection.v1.MsgConnectionOpenConfirm" AND chain_id = ?
 		require.NoError(t, r.CreateChannel(ctx, eRep, pathName, ibc.CreateChannelOptions{
 			SourcePortName: gaia0Port,
 			DestPortName:   gaia1Port,
-			Order:          "unordered",
+			Order:          ibc.Unordered,
 			Version:        "ics20-1",
 		}))
 

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -192,8 +192,8 @@ func (r *DockerRelayer) GetConnections(ctx context.Context, rep ibc.RelayerExecR
 	return r.c.ParseGetConnectionsOutput(stdout, stderr)
 }
 
-func (r *DockerRelayer) LinkPath(ctx context.Context, rep ibc.RelayerExecReporter, pathName string) error {
-	cmd := r.c.LinkPath(pathName, r.NodeHome())
+func (r *DockerRelayer) LinkPath(ctx context.Context, rep ibc.RelayerExecReporter, pathName string, opts ibc.CreateChannelOptions) error {
+	cmd := r.c.LinkPath(pathName, r.NodeHome(), opts)
 	return dockerutil.HandleNodeJobError(r.NodeJob(ctx, rep, cmd))
 }
 
@@ -463,7 +463,7 @@ type RelayerCommander interface {
 	GeneratePath(srcChainID, dstChainID, pathName, homeDir string) []string
 	GetChannels(chainID, homeDir string) []string
 	GetConnections(chainID, homeDir string) []string
-	LinkPath(pathName, homeDir string) []string
+	LinkPath(pathName, homeDir string, opts ibc.CreateChannelOptions) []string
 	RestoreKey(chainID, keyName, mnemonic, homeDir string) []string
 	StartRelayer(pathName, homeDir string) []string
 	UpdateClients(pathName, homeDir string) []string

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -116,7 +116,7 @@ func (commander) CreateChannel(pathName string, opts ibc.CreateChannelOptions, h
 		"rly", "tx", "channel", pathName,
 		"--src-port", opts.SourcePortName,
 		"--dst-port", opts.DestPortName,
-		"--order", opts.Order,
+		"--order", opts.Order.String(),
 		"--version", opts.Version,
 
 		"--home", homeDir,
@@ -177,7 +177,7 @@ func (commander) LinkPath(pathName, homeDir string, opts ibc.CreateChannelOption
 		"rly", "tx", "link", pathName,
 		"--src-port", opts.SourcePortName,
 		"--dst-port", opts.DestPortName,
-		"--order", opts.Order,
+		"--order", opts.Order.String(),
 		"--version", opts.Version,
 
 		"--home", homeDir,

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -172,9 +172,14 @@ func (commander) GetConnections(chainID, homeDir string) []string {
 	}
 }
 
-func (commander) LinkPath(pathName, homeDir string) []string {
+func (commander) LinkPath(pathName, homeDir string, opts ibc.CreateChannelOptions) []string {
 	return []string{
 		"rly", "tx", "link", pathName,
+		"--src-port", opts.SourcePortName,
+		"--dst-port", opts.DestPortName,
+		"--order", opts.Order,
+		"--version", opts.Version,
+
 		"--home", homeDir,
 	}
 }

--- a/test_setup.go
+++ b/test_setup.go
@@ -102,6 +102,7 @@ func StartChainPairAndRelayer(
 		NetworkID:         networkID,
 		GitSha:            version.GitSha,
 		BlockDatabaseFile: blockSqlite,
+		CreateChannelOpts: ibc.DefaultChannelOpts(),
 	}); err != nil {
 		return errResponse(err)
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR addresses #155 by adding adding `CreateChannelOptions` as a field to the `InterchainBuildOptions` struct as well as adding it as a parameter to `LinkPath`.

If `CreateChannelOptions` are not specified on the `InterchainBuildOptions` struct then when the paths are linked in `interchain.Build` we default to the channel configuration options for an ics20 token transfer channel.

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project