### PR TITLE
Add ibctest.TempDir function

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ ibctest -test.run=//gaia/rly/
 ibctest -test.run=//gaia/rly/conformance/no_timeout
 ```
 
+## Retaining data on failed tests
+
+By default, failed tests will clean up any temporary directories they created.
+Sometimes when debugging a failed test, it can be more helpful to leave the directory behind
+for further manual inspection.
+
+Setting the environment variable `IBCTEST_SKIP_FAILURE_CLEANUP` to any non-empty value
+will cause the test to skip deletion of the temporary directories.
+Any tests that fail and skip cleanup will log a message like
+`Not removing temporary directory for test at: /tmp/...`.
+
+Test authors must use
+[`ibctest.TempDir`](https://pkg.go.dev/github.com/strangelove-ventures/ibctest#TempDir)
+instead of `(*testing.T).Cleanup` to opt in to this behavior.
+
 ## Contributing
 
 Running `make ibctest` will produce an `ibctest` binary into `./bin`.

--- a/chain/penumbra/penumbra_chain_test.go
+++ b/chain/penumbra/penumbra_chain_test.go
@@ -19,7 +19,7 @@ func TestPenumbraChainStart(t *testing.T) {
 	t.Parallel()
 
 	pool, network := ibctest.DockerSetup(t)
-	home := t.TempDir() // Must be before chain cleanup to avoid test error during cleanup.
+	home := ibctest.TempDir(t) // Must be before chain cleanup to avoid test error during cleanup.
 
 	nv := 4
 

--- a/conformance/flush.go
+++ b/conformance/flush.go
@@ -21,7 +21,7 @@ func TestRelayerFlushing(t *testing.T, cf ibctest.ChainFactory, rf ibctest.Relay
 	// but check that capability first in case we can avoid setup.
 	requireCapabilities(t, rep, rf, relayer.FlushPackets)
 
-	home := t.TempDir()
+	home := ibctest.TempDir(t)
 	pool, network := ibctest.DockerSetup(t)
 
 	req := require.New(rep.TestifyT(t))

--- a/conformance/relayersetup.go
+++ b/conformance/relayersetup.go
@@ -18,7 +18,7 @@ import (
 func TestRelayerSetup(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory, rep *testreporter.Reporter) {
 	rep.TrackTest(t)
 
-	home := t.TempDir()
+	home := ibctest.TempDir(t)
 	pool, network := ibctest.DockerSetup(t)
 
 	req := require.New(rep.TestifyT(t))

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -304,7 +304,7 @@ func TestChainPair(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFact
 	// funds relayer src and dst wallets on respective chain in genesis
 	// creates a faucet account on the both chains (separate fullnode)
 	// funds faucet accounts in genesis
-	home := t.TempDir()
+	home := ibctest.TempDir(t)
 	_, channels, err := ibctest.StartChainPairAndRelayer(t, ctx, rep, pool, network, home, srcChain, dstChain, rf, preRelayerStartFuncs)
 	req.NoError(err, "failed to StartChainPairAndRelayer")
 

--- a/interchain_test.go
+++ b/interchain_test.go
@@ -21,7 +21,7 @@ func TestInterchain_DuplicateChain(t *testing.T) {
 
 	t.Parallel()
 
-	home := t.TempDir()
+	home := ibctest.TempDir(t)
 	pool, network := ibctest.DockerSetup(t)
 
 	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
@@ -71,7 +71,7 @@ func TestInterchain_GetRelayerWallets(t *testing.T) {
 
 	t.Parallel()
 
-	home := t.TempDir()
+	home := ibctest.TempDir(t)
 	pool, network := ibctest.DockerSetup(t)
 
 	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
@@ -154,7 +154,7 @@ func TestInterchain_OmitGitSHA(t *testing.T) {
 
 	t.Parallel()
 
-	home := t.TempDir()
+	home := ibctest.TempDir(t)
 	pool, network := ibctest.DockerSetup(t)
 
 	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{

--- a/internal/blockdb/messages_view_test.go
+++ b/internal/blockdb/messages_view_test.go
@@ -26,7 +26,7 @@ func TestMessagesView(t *testing.T) {
 
 	t.Parallel()
 
-	home := t.TempDir()
+	home := ibctest.TempDir(t)
 	pool, network := ibctest.DockerSetup(t)
 
 	const gaia0ChainID = "g0"
@@ -54,7 +54,7 @@ func TestMessagesView(t *testing.T) {
 			Relayer: r,
 		})
 
-	dbDir := t.TempDir()
+	dbDir := ibctest.TempDir(t)
 	dbPath := filepath.Join(dbDir, "blocks.db")
 
 	rep := testreporter.NewNopReporter()

--- a/tempdir.go
+++ b/tempdir.go
@@ -25,9 +25,9 @@ type TempDirTestingT interface {
 // is retained or deleted following a test failure.
 //
 // It defaults to false, but can be initialized to true by setting the
-// environment variable IBCTEST_KEEP_FAILURE_DIR to a non-empty value.
+// environment variable IBCTEST_SKIP_FAILURE_CLEANUP to a non-empty value.
 // Alternatively, importers of the ibctest package may set the variable to true.
-var KeepTempDirOnFailure = os.Getenv("IBCTEST_KEEP_FAILURE_DIR") != ""
+var KeepTempDirOnFailure = os.Getenv("IBCTEST_SKIP_FAILURE_CLEANUP") != ""
 
 // TempDir resembles (*testing.T).TempDir, except that it conditionally
 // keeps the temporary directory on disk, and it uses a new temporary directory

--- a/tempdir.go
+++ b/tempdir.go
@@ -1,0 +1,91 @@
+package ibctest
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// TempDirTestingT is a subset of testing.TB to implement TempDir.
+type TempDirTestingT interface {
+	Helper()
+
+	Name() string
+
+	Failed() bool
+	Cleanup(func())
+
+	Logf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+}
+
+// KeepTempDirOnFailure determines whether a directory created by TempDir
+// is retained or deleted following a test failure.
+//
+// It defaults to false, but can be initialized to true by setting the
+// environment variable IBCTEST_KEEP_FAILURE_DIR to a non-empty value.
+// Alternatively, importers of the ibctest package may set the variable to true.
+var KeepTempDirOnFailure = os.Getenv("IBCTEST_KEEP_FAILURE_DIR") != ""
+
+// TempDir resembles (*testing.T).TempDir, except that it conditionally
+// keeps the temporary directory on disk, and it uses a new temporary directory
+// on each invocation instead of adjacent directories with an incrementing numeric suffix.
+//
+// If the test passes, or if the package-level variable KeepTempDirOnFailure is false,
+// the directory will be removed.
+func TempDir(t TempDirTestingT) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", sanitizeTestName(t.Name()))
+	if err != nil {
+		// Realistically this should never fail.
+		// Panicking allows a slimmer TempDirTestingT interface
+		// (because we don't need to include Fatalf).
+		panic(fmt.Errorf("TempDir: %w", err))
+	}
+
+	t.Cleanup(func() {
+		if KeepTempDirOnFailure && t.Failed() {
+			t.Logf("Not removing temporary directory for test at: %s", dir)
+			return
+		}
+
+		if err := os.RemoveAll(dir); err != nil {
+			// Same error message as (*testing.T).TempDir.
+			// If the directory can't be cleaned up,
+			// that usually indicates something is subtly wrong.
+			// Most often it seems to be something still writing to the directory
+			// even though the test has ostensibly finished.
+			t.Errorf("TempDir RemoveAll cleanup: %v", err)
+		}
+	})
+
+	return dir
+}
+
+func sanitizeTestName(name string) string {
+	// Copied from the standard library's (*testing.T).Cleanup:
+
+	// Drop unusual characters (such as path separators or
+	// characters interacting with globs) from the directory name to
+	// avoid surprising os.MkdirTemp behavior.
+	mapper := func(r rune) rune {
+		if r < utf8.RuneSelf {
+			const allowed = "!#$%&()+,-.=@^_{}~ "
+			if '0' <= r && r <= '9' ||
+				'a' <= r && r <= 'z' ||
+				'A' <= r && r <= 'Z' {
+				return r
+			}
+			if strings.ContainsRune(allowed, r) {
+				return r
+			}
+		} else if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			return r
+		}
+		return -1
+	}
+	return strings.Map(mapper, name)
+}

--- a/tempdir_test.go
+++ b/tempdir_test.go
@@ -1,0 +1,147 @@
+package ibctest_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/strangelove-ventures/ibctest"
+	"github.com/stretchr/testify/require"
+)
+
+type mockTempT struct {
+	name string
+
+	failed bool
+
+	helperCalled bool
+
+	cleanups []func()
+
+	logs   []string
+	errors []string
+}
+
+func (t *mockTempT) Helper() {
+	t.helperCalled = true
+}
+
+func (t *mockTempT) Name() string {
+	return t.name
+}
+
+func (t *mockTempT) Failed() bool {
+	return t.failed
+}
+
+func (t *mockTempT) Cleanup(f func()) {
+	t.cleanups = append(t.cleanups, f)
+}
+
+func (t *mockTempT) RunCleanups() {
+	// Cleanups are run in reverse order of insertion.
+	for i := len(t.cleanups) - 1; i >= 0; i-- {
+		t.cleanups[i]()
+	}
+	t.cleanups = nil
+}
+
+func (t *mockTempT) Logf(format string, args ...interface{}) {
+	t.logs = append(t.logs, fmt.Sprintf(format, args...))
+}
+
+func (t *mockTempT) Errorf(format string, args ...interface{}) {
+	t.errors = append(t.errors, fmt.Sprintf(format, args...))
+}
+
+func TestTempDir_Cleanup(t *testing.T) {
+	origKeep := ibctest.KeepTempDirOnFailure
+	defer func() {
+		ibctest.KeepTempDirOnFailure = origKeep
+	}()
+
+	t.Run("keep=true", func(t *testing.T) {
+		ibctest.KeepTempDirOnFailure = true
+
+		t.Run("test passed", func(t *testing.T) {
+			mt := &mockTempT{name: "t"}
+
+			dir := ibctest.TempDir(mt)
+			require.DirExists(t, dir)
+
+			mt.RunCleanups()
+
+			require.NoDirExists(t, dir)
+			require.Empty(t, mt.logs)
+		})
+
+		t.Run("test failed", func(t *testing.T) {
+			mt := &mockTempT{name: "t"}
+
+			dir := ibctest.TempDir(mt)
+			require.DirExists(t, dir)
+			defer func() { _ = os.RemoveAll(dir) }()
+
+			mt.failed = true
+
+			mt.RunCleanups()
+
+			// Directory still exists after cleanups.
+			require.DirExists(t, dir)
+
+			// And the last log message mentions the directory.
+			require.NotEmpty(t, mt.logs)
+			require.Contains(t, mt.logs[len(mt.logs)-1], dir)
+		})
+	})
+
+	t.Run("keep=false", func(t *testing.T) {
+		ibctest.KeepTempDirOnFailure = false
+
+		for name, failed := range map[string]bool{
+			"test passed": false,
+			"test failed": true,
+		} {
+			failed := failed
+			t.Run(name, func(t *testing.T) {
+				mt := &mockTempT{name: "t"}
+
+				dir := ibctest.TempDir(mt)
+				require.DirExists(t, dir)
+
+				mt.failed = failed
+
+				mt.RunCleanups()
+
+				require.NoDirExists(t, dir)
+				require.Empty(t, mt.logs)
+			})
+		}
+	})
+}
+
+func TestTempDir_Naming(t *testing.T) {
+	const testNamePrefix = "TestTempDir_Naming"
+	tmpRoot := os.TempDir()
+
+	for name, expDir := range map[string]string{
+		"A":        "A",
+		"Foo_Bar":  "Foo_Bar",
+		"1/2 full": "12_full",
+		"/..":      "..", // Gets prefix appended, so will not traverse upwards.
+		"\x00\xFF": "",
+	} {
+		wantDir := filepath.Join(tmpRoot, testNamePrefix+expDir)
+		t.Run(name, func(t *testing.T) {
+			dir := ibctest.TempDir(t)
+
+			require.Truef(
+				t,
+				strings.HasPrefix(dir, wantDir),
+				"directory %s should have started with %s", dir, wantDir,
+			)
+		})
+	}
+}


### PR DESCRIPTION
This behaves similarly to `(*testing.T).TempDir()`, except that it
supports runtime configuration to determine whether to remove created
directories for failed tests.

By default, the created directories are removed as part of t.Cleanup. If
the environment variable `IBCTEST_KEEP_FAILURE_DIR` is set to any
non-empty value, and if the test failed, then the test will log that the
directory is not being cleaned up.

Importers of the ibctest package also have the option to set the package
level variable `KeepTempDirOnFailure` to opt in to this behavior.

Closes #168.