### PR TITLE
Adding support for `RecoverKey` in the chain interface.

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -321,6 +321,18 @@ func (tn *ChainNode) CreateKey(ctx context.Context, name string) error {
 	return dockerutil.HandleNodeJobError(tn.NodeJob(ctx, command))
 }
 
+// RecoverKey restores a key from a given mnemonic.
+func (tn *ChainNode) RecoverKey(ctx context.Context, keyName, mnemonic string) error {
+	command := []string{
+		tn.Chain.Config().GetShell(),
+		"-c",
+		fmt.Sprintf(`echo "%s" | %s keys add %s --recover --keyring-backend %s --home %s --output json`, mnemonic, tn.Chain.Config().Bin, keyName, keyring.BackendTest, tn.NodeHome()),
+	}
+	tn.lock.Lock()
+	defer tn.lock.Unlock()
+	return dockerutil.HandleNodeJobError(tn.NodeJob(ctx, command))
+}
+
 // AddGenesisAccount adds a genesis account for each key
 func (tn *ChainNode) AddGenesisAccount(ctx context.Context, address string, genesisAmount []types.Coin) error {
 	amount := ""

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -324,9 +324,9 @@ func (tn *ChainNode) CreateKey(ctx context.Context, name string) error {
 // RecoverKey restores a key from a given mnemonic.
 func (tn *ChainNode) RecoverKey(ctx context.Context, keyName, mnemonic string) error {
 	command := []string{
-		tn.Chain.Config().GetShell(),
+		"sh",
 		"-c",
-		fmt.Sprintf(`echo "%s" | %s keys add %s --recover --keyring-backend %s --home %s --output json`, mnemonic, tn.Chain.Config().Bin, keyName, keyring.BackendTest, tn.NodeHome()),
+		fmt.Sprintf(`echo %q | %s keys add %s --recover --keyring-backend %s --home %s --output json`, mnemonic, tn.Chain.Config().Bin, keyName, keyring.BackendTest, tn.NodeHome()),
 	}
 	tn.lock.Lock()
 	defer tn.lock.Unlock()

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -330,7 +330,8 @@ func (tn *ChainNode) RecoverKey(ctx context.Context, keyName, mnemonic string) e
 	}
 	tn.lock.Lock()
 	defer tn.lock.Unlock()
-	return dockerutil.HandleNodeJobError(tn.NodeJob(ctx, command))
+	_, _, err := tn.Exec(ctx, command, nil)
+	return err
 }
 
 // AddGenesisAccount adds a genesis account for each key

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -126,6 +126,11 @@ func (c *CosmosChain) CreateKey(ctx context.Context, keyName string) error {
 }
 
 // Implements Chain interface
+func (c *CosmosChain) RecoverKey(ctx context.Context, keyName, mnemonic string) error {
+	return c.getFullNode().RecoverKey(ctx, keyName, mnemonic)
+}
+
+// Implements Chain interface
 func (c *CosmosChain) GetAddress(ctx context.Context, keyName string) ([]byte, error) {
 	keyInfo, err := c.getFullNode().Keybase().Key(keyName)
 	if err != nil {

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -140,6 +140,10 @@ func (c *PenumbraChain) CreateKey(ctx context.Context, keyName string) error {
 	return c.getRelayerNode().PenumbraAppNode.CreateKey(ctx, keyName)
 }
 
+func (c *PenumbraChain) RecoverKey(ctx context.Context, name, mnemonic string) error {
+	return fmt.Errorf("RecoverKey not implemented for PenumbraChain")
+}
+
 // Implements Chain interface
 func (c *PenumbraChain) GetAddress(ctx context.Context, keyName string) ([]byte, error) {
 	return c.getRelayerNode().PenumbraAppNode.GetAddress(ctx, keyName)

--- a/ibc/chain.go
+++ b/ibc/chain.go
@@ -39,6 +39,9 @@ type Chain interface {
 	// creates a test key in the "user" node, (either the first fullnode or the first validator if no fullnodes)
 	CreateKey(ctx context.Context, keyName string) error
 
+	// RecoverKey recovers an existing user from a given mnemonic.
+	RecoverKey(ctx context.Context, name, mnemonic string) error
+
 	// fetches the bech32 address for a test key on the "user" node (either the first fullnode or the first validator if no fullnodes)
 	GetAddress(ctx context.Context, keyName string) ([]byte, error)
 

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -14,6 +14,7 @@ type ChainConfig struct {
 	GasAdjustment  float64
 	TrustingPeriod string
 	NoHostMount    bool
+	Shell          string
 }
 
 func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
@@ -60,6 +61,14 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 	// Skip NoHostMount so that false can be distinguished.
 
 	return c
+}
+
+// GetShell returns the shell that should be used when executing scripts.
+func (c ChainConfig) GetShell() string {
+	if c.Shell == "" {
+		return "sh"
+	}
+	return c.Shell
 }
 
 // IsFullyConfigured reports whether all required fields have been set on c.

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -14,7 +14,6 @@ type ChainConfig struct {
 	GasAdjustment  float64
 	TrustingPeriod string
 	NoHostMount    bool
-	Shell          string
 }
 
 func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
@@ -61,14 +60,6 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 	// Skip NoHostMount so that false can be distinguished.
 
 	return c
-}
-
-// GetShell returns the shell that should be used when executing scripts.
-func (c ChainConfig) GetShell() string {
-	if c.Shell == "" {
-		return "sh"
-	}
-	return c.Shell
 }
 
 // IsFullyConfigured reports whether all required fields have been set on c.

--- a/test_user.go
+++ b/test_user.go
@@ -46,6 +46,7 @@ func generateUserWallet(ctx context.Context, keyName, mnemonic string, chain ibc
 
 // GetAndFundTestUserWithMnemonic restores a user using the given mnemonic
 // and funds it with the native chain denom.
+// The caller should wait for some blocks to complete before the funds will be accessible.
 func GetAndFundTestUserWithMnemonic(
 	t *testing.T,
 	ctx context.Context,
@@ -64,12 +65,12 @@ func GetAndFundTestUserWithMnemonic(
 		Denom:   chainCfg.Denom,
 	})
 	require.NoError(t, err, "failed to get funds from faucet")
-	require.NoError(t, test.WaitForBlocks(ctx, 5, chain), "failed to wait for blocks")
 
 	return user
 }
 
-// generate and fund chain users
+// GetAndFundTestUsers generates and funds chain users with the native chain denom.
+// The caller should wait for some blocks to complete before the funds will be accessible.
 func GetAndFundTestUsers(
 	t *testing.T,
 	ctx context.Context,
@@ -88,8 +89,5 @@ func GetAndFundTestUsers(
 	for i := range chains {
 		chainHeights[i] = chains[i]
 	}
-
-	require.NoError(t, test.WaitForBlocks(ctx, 5, chainHeights...), "failed to wait for blocks")
-
 	return users
 }

--- a/test_user.go
+++ b/test_user.go
@@ -22,9 +22,16 @@ func (u *User) Bech32Address(bech32Prefix string) string {
 }
 
 // generateUserWallet creates a new user wallet with the given key name on the given chain.
-func generateUserWallet(ctx context.Context, keyName string, chain ibc.Chain) (*User, error) {
-	if err := chain.CreateKey(ctx, keyName); err != nil {
-		return nil, fmt.Errorf("failed to create key on source chain: %w", err)
+// a user is recovered if a mnemonic is specified.
+func generateUserWallet(ctx context.Context, keyName, mnemonic string, chain ibc.Chain) (*User, error) {
+	if mnemonic != "" {
+		if err := chain.RecoverKey(ctx, keyName, mnemonic); err != nil {
+			return nil, fmt.Errorf("failed to recover key on source chain: %w", err)
+		}
+	} else {
+		if err := chain.CreateKey(ctx, keyName); err != nil {
+			return nil, fmt.Errorf("failed to create key on source chain: %w", err)
+		}
 	}
 	userAccountAddressBytes, err := chain.GetAddress(ctx, keyName)
 	if err != nil {
@@ -37,6 +44,31 @@ func generateUserWallet(ctx context.Context, keyName string, chain ibc.Chain) (*
 	return &user, nil
 }
 
+// GetAndFundTestUserWithMnemonic restores a user using the given mnemonic
+// and funds it with the native chain denom.
+func GetAndFundTestUserWithMnemonic(
+	t *testing.T,
+	ctx context.Context,
+	keyNamePrefix, mnemonic string,
+	amount int64,
+	chain ibc.Chain,
+) *User {
+	chainCfg := chain.Config()
+	keyName := fmt.Sprintf("%s-%s-%s", keyNamePrefix, chainCfg.ChainID, dockerutil.RandLowerCaseLetterString(3))
+	user, err := generateUserWallet(ctx, keyName, mnemonic, chain)
+	require.NoError(t, err, "failed to get source user wallet")
+
+	err = chain.SendFunds(ctx, FaucetAccountKeyName, ibc.WalletAmount{
+		Address: user.Bech32Address(chainCfg.Bech32Prefix),
+		Amount:  amount,
+		Denom:   chainCfg.Denom,
+	})
+	require.NoError(t, err, "failed to get funds from faucet")
+	require.NoError(t, test.WaitForBlocks(ctx, 5, chain), "failed to wait for blocks")
+
+	return user
+}
+
 // generate and fund chain users
 func GetAndFundTestUsers(
 	t *testing.T,
@@ -47,19 +79,8 @@ func GetAndFundTestUsers(
 ) []*User {
 	var users []*User
 	for _, chain := range chains {
-		chainCfg := chain.Config()
-		keyName := fmt.Sprintf("%s-%s-%s", keyNamePrefix, chainCfg.ChainID, dockerutil.RandLowerCaseLetterString(3))
-		user, err := generateUserWallet(ctx, keyName, chain)
-		require.NoError(t, err, "failed to get source user wallet")
-
+		user := GetAndFundTestUserWithMnemonic(t, ctx, keyNamePrefix, "", amount, chain)
 		users = append(users, user)
-
-		err = chain.SendFunds(ctx, FaucetAccountKeyName, ibc.WalletAmount{
-			Address: user.Bech32Address(chainCfg.Bech32Prefix),
-			Amount:  amount,
-			Denom:   chainCfg.Denom,
-		})
-		require.NoError(t, err, "failed to get funds from faucet")
 	}
 
 	// TODO(nix 05-17-2022): Map with generics once using go 1.18


### PR DESCRIPTION
## Description

This PR adds the functionality to recover a test user from a given mnemonic.

## Checklist

- [X] I have made sure the upstream branch for this PR is correct
- [X] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project

## Changes

- [x] Added `RecoverKey` to `ChainNode` and `CosmosChain` types.
- [x] Added `RecoverKey` to `Chain` interface.
- [ ] ~Added `Shell` field to `ChainConfig`. This is to allow you to specify which shell commands which run using `-c <script>` will use, as not all images will have the same shells.~
- [x] Added `GetAndFundTestUserWithMnemonic` which generates a user using a given mnemonic.
- [x] Changed `GetAndFundTestUsers` to delegate to `GetAndFundTestUserWithMnemonic`
- [x] Changed `generateUserWallet` to either `Create` or `Recover` based on the presence of a mnemonic.


## Testing

Tests have been added which verify that users can be created using `CreateKey` and `RecoverKey`


closes #169
