### PR TITLE
Reduce timeout on starting container for cosmos chain node

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -714,7 +714,7 @@ func (tn *ChainNode) StartContainer(ctx context.Context) error {
 				stat.SyncInfo.LatestBlockHeight, stat.SyncInfo.CatchingUp)
 		}
 		return nil
-	}, retry.Context(ctx), retry.Attempts(100), retry.Delay(5*time.Second), retry.DelayType(retry.FixedDelay))
+	}, retry.Context(ctx), retry.Attempts(40), retry.Delay(3*time.Second), retry.DelayType(retry.FixedDelay))
 }
 
 // InitValidatorFiles creates the node files and signs a genesis transaction


### PR DESCRIPTION
This step fails somewhat frequently on my workstation, with 100 tries of
a message like this:

post failed: Post "http://localhost:55493": dial tcp [::1]:55493: connect: connection refused

I'm not sure why it is refusing the connection, but 100 tries with a 5s
sleep between each try is over 8 minutes of waiting to find out that the
test will fail.

Arbitrarily reduce the tries to 40 and the inter-try sleep to 3s, so
that this will only try for about 3 minutes.
