### PR TITLE
RelayerOption for additional startup flags

### DIFF
--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -65,11 +65,11 @@ func NewDockerRelayer(log *zap.Logger, testName, home string, pool *dockertest.P
 	}
 
 	for _, opt := range options {
-		switch typedOpt := opt.(type) {
+		switch o := opt.(type) {
 		case RelayerOptionDockerImage:
-			relayer.customImage = &typedOpt.DockerImage
+			relayer.customImage = &o.DockerImage
 		case RelayerOptionImagePull:
-			relayer.pullImage = typedOpt.Pull
+			relayer.pullImage = o.Pull
 		}
 	}
 

--- a/relayer/options.go
+++ b/relayer/options.go
@@ -43,7 +43,7 @@ type RelayerOptionStartupFlags struct {
 	Flags []string
 }
 
-func StartupFlags(flags []string) RelayerOption {
+func StartupFlags(flags ...string) RelayerOption {
 	return RelayerOptionStartupFlags{
 		Flags: flags,
 	}

--- a/relayer/options.go
+++ b/relayer/options.go
@@ -40,10 +40,10 @@ func ImagePull(pull bool) RelayerOption {
 func (opt RelayerOptionImagePull) relayerOption() {}
 
 type RelayerOptionStartupFlags struct {
-	Flags string
+	Flags []string
 }
 
-func StartupFlags(flags string) RelayerOption {
+func StartupFlags(flags []string) RelayerOption {
 	return RelayerOptionStartupFlags{
 		Flags: flags,
 	}

--- a/relayer/options.go
+++ b/relayer/options.go
@@ -38,3 +38,15 @@ func ImagePull(pull bool) RelayerOption {
 }
 
 func (opt RelayerOptionImagePull) relayerOption() {}
+
+type RelayerOptionStartupFlags struct {
+	Flags string
+}
+
+func StartupFlags(flags string) RelayerOption {
+	return RelayerOptionStartupFlags{
+		Flags: flags,
+	}
+}
+
+func (opt RelayerOptionStartupFlags) relayerOption() {}

--- a/relayer/options.go
+++ b/relayer/options.go
@@ -39,14 +39,14 @@ func ImagePull(pull bool) RelayerOption {
 
 func (opt RelayerOptionImagePull) relayerOption() {}
 
-type RelayerOptionStartupFlags struct {
+type RelayerOptionExtraStartFlags struct {
 	Flags []string
 }
 
 func StartupFlags(flags ...string) RelayerOption {
-	return RelayerOptionStartupFlags{
+	return RelayerOptionExtraStartFlags{
 		Flags: flags,
 	}
 }
 
-func (opt RelayerOptionStartupFlags) relayerOption() {}
+func (opt RelayerOptionExtraStartFlags) relayerOption() {}

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -24,9 +24,9 @@ type CosmosRelayer struct {
 func NewCosmosRelayer(log *zap.Logger, testName, home string, pool *dockertest.Pool, networkID string, options ...relayer.RelayerOption) *CosmosRelayer {
 	c := commander{log: log}
 	for _, opt := range options {
-		switch typedOpt := opt.(type) {
+		switch o := opt.(type) {
 		case relayer.RelayerOptionExtraStartFlags:
-			c.extraStartFlags = typedOpt.Flags
+			c.extraStartFlags = o.Flags
 		}
 	}
 	r := &CosmosRelayer{

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -23,6 +23,12 @@ type CosmosRelayer struct {
 
 func NewCosmosRelayer(log *zap.Logger, testName, home string, pool *dockertest.Pool, networkID string, options ...relayer.RelayerOption) *CosmosRelayer {
 	c := commander{log: log}
+	for _, opt := range options {
+		switch typedOpt := opt.(type) {
+		case relayer.RelayerOptionStartupFlags:
+			c.startupFlags = typedOpt.Flags
+		}
+	}
 	r := &CosmosRelayer{
 		DockerRelayer: relayer.NewDockerRelayer(log, testName, home, pool, networkID, c, options...),
 	}
@@ -90,7 +96,8 @@ func ChainConfigToCosmosRelayerChainConfig(chainConfig ibc.ChainConfig, keyName,
 
 // commander satisfies relayer.RelayerCommander.
 type commander struct {
-	log *zap.Logger
+	log          *zap.Logger
+	startupFlags string
 }
 
 func (commander) Name() string {
@@ -191,11 +198,15 @@ func (commander) RestoreKey(chainID, keyName, mnemonic, homeDir string) []string
 	}
 }
 
-func (commander) StartRelayer(pathName, homeDir string) []string {
-	return []string{
+func (c commander) StartRelayer(pathName, homeDir string) []string {
+	cmd := []string{
 		"rly", "start", pathName, "--debug",
 		"--home", homeDir,
 	}
+	if c.startupFlags != "" {
+		cmd = append(cmd, strings.Split(c.startupFlags, " ")...)
+	}
+	return cmd
 }
 
 func (commander) UpdateClients(pathName, homeDir string) []string {

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -25,8 +25,8 @@ func NewCosmosRelayer(log *zap.Logger, testName, home string, pool *dockertest.P
 	c := commander{log: log}
 	for _, opt := range options {
 		switch typedOpt := opt.(type) {
-		case relayer.RelayerOptionStartupFlags:
-			c.startupFlags = typedOpt.Flags
+		case relayer.RelayerOptionExtraStartFlags:
+			c.extraStartFlags = typedOpt.Flags
 		}
 	}
 	r := &CosmosRelayer{
@@ -96,8 +96,8 @@ func ChainConfigToCosmosRelayerChainConfig(chainConfig ibc.ChainConfig, keyName,
 
 // commander satisfies relayer.RelayerCommander.
 type commander struct {
-	log          *zap.Logger
-	startupFlags []string
+	log             *zap.Logger
+	extraStartFlags []string
 }
 
 func (commander) Name() string {
@@ -203,7 +203,7 @@ func (c commander) StartRelayer(pathName, homeDir string) []string {
 		"rly", "start", pathName, "--debug",
 		"--home", homeDir,
 	}
-	cmd = append(cmd, c.startupFlags...)
+	cmd = append(cmd, c.extraStartFlags...)
 	return cmd
 }
 

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -97,7 +97,7 @@ func ChainConfigToCosmosRelayerChainConfig(chainConfig ibc.ChainConfig, keyName,
 // commander satisfies relayer.RelayerCommander.
 type commander struct {
 	log          *zap.Logger
-	startupFlags string
+	startupFlags []string
 }
 
 func (commander) Name() string {
@@ -203,9 +203,7 @@ func (c commander) StartRelayer(pathName, homeDir string) []string {
 		"rly", "start", pathName, "--debug",
 		"--home", homeDir,
 	}
-	if c.startupFlags != "" {
-		cmd = append(cmd, strings.Split(c.startupFlags, " ")...)
-	}
+	cmd = append(cmd, c.startupFlags...)
 	return cmd
 }
 

--- a/relayerfactory.go
+++ b/relayerfactory.go
@@ -80,9 +80,9 @@ func (f builtinRelayerFactory) Name() string {
 		// so that the slashes in the image repository don't add ambiguity
 		// to subtest paths, when the factory name is used in calls to t.Run.
 		for _, opt := range f.options {
-			switch typedOpt := opt.(type) {
+			switch o := opt.(type) {
 			case relayer.RelayerOptionDockerImage:
-				return "rly@" + typedOpt.DockerImage.Version
+				return "rly@" + o.DockerImage.Version
 			}
 		}
 		return "rly@" + rly.DefaultContainerVersion


### PR DESCRIPTION
`StartupFlags` `RelayerOption` to append to the `StartRelayer` `commander` command. Will need to be implemented if needed separately for future `RelayerCommander` implementations.