### PR TITLE
Add Ref() method on ibc.DockerImage

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -666,7 +666,7 @@ func (tn *ChainNode) CreateNodeContainer(ctx context.Context) error {
 	cc, err := tn.DockerClient.ContainerCreate(
 		ctx,
 		&container.Config{
-			Image: tn.Image.Repository + ":" + tn.Image.Version,
+			Image: tn.Image.Ref(),
 
 			Entrypoint: []string{},
 			Cmd:        cmd,

--- a/chain/internal/tendermint/tendermint_node.go
+++ b/chain/internal/tendermint/tendermint_node.go
@@ -190,7 +190,7 @@ func (tn *TendermintNode) CreateNodeContainer(ctx context.Context, additionalFla
 	cc, err := tn.DockerClient.ContainerCreate(
 		ctx,
 		&container.Config{
-			Image: tn.Image.Repository + ":" + tn.Image.Version,
+			Image: tn.Image.Ref(),
 
 			Entrypoint: []string{},
 			Cmd:        cmd,

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -238,7 +238,7 @@ func (p *PenumbraAppNode) CreateNodeContainer(ctx context.Context) error {
 	cc, err := p.DockerClient.ContainerCreate(
 		ctx,
 		&container.Config{
-			Image: p.Image.Repository + ":" + p.Image.Version,
+			Image: p.Image.Ref(),
 
 			Cmd: cmd,
 

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -82,6 +82,15 @@ type DockerImage struct {
 	Version    string
 }
 
+// Ref returns the reference to use when e.g. creating a container.
+func (i DockerImage) Ref() string {
+	if i.Version == "" {
+		return i.Repository + ":latest"
+	}
+
+	return i.Repository + ":" + i.Version
+}
+
 type WalletAmount struct {
 	Address string
 	Denom   string

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -80,7 +80,7 @@ func NewDockerRelayer(log *zap.Logger, testName, home string, cli *client.Client
 
 	containerImage := relayer.containerImage()
 	if err := relayer.pullContainerImageIfNecessary(containerImage); err != nil {
-		log.Error("Error pulling container image", zap.String("repository", containerImage.Repository), zap.String("version", containerImage.Version), zap.Error(err))
+		log.Error("Error pulling container image", zap.String("ref", containerImage.Ref()), zap.Error(err))
 	}
 
 	return &relayer
@@ -327,8 +327,7 @@ func (r *DockerRelayer) pullContainerImageIfNecessary(containerImage ibc.DockerI
 		return nil
 	}
 
-	ref := containerImage.Repository + ":" + containerImage.Version
-	rc, err := r.client.ImagePull(context.TODO(), ref, types.ImagePullOptions{})
+	rc, err := r.client.ImagePull(context.TODO(), containerImage.Ref(), types.ImagePullOptions{})
 	if err != nil {
 		return err
 	}
@@ -350,7 +349,7 @@ func (r *DockerRelayer) createNodeContainer(ctx context.Context, pathName string
 	cc, err := r.client.ContainerCreate(
 		ctx,
 		&container.Config{
-			Image: fmt.Sprintf("%s:%s", containerImage.Repository, containerImage.Version),
+			Image: containerImage.Ref(),
 
 			Entrypoint: []string{},
 			Cmd:        cmd,
@@ -412,7 +411,7 @@ func (r *DockerRelayer) NodeJob(ctx context.Context, rep ibc.RelayerExecReporter
 	cc, err := r.client.ContainerCreate(
 		ctx,
 		&container.Config{
-			Image: containerImage.Repository + ":" + containerImage.Version,
+			Image: containerImage.Ref(),
 
 			Entrypoint: []string{},
 			Cmd:        cmd,


### PR DESCRIPTION
So that we can consistently generate the image reference, i.e.
`$REPO:$TAG`. If we later support image hashes, this method will generate
the proper `$REPO@sha256:$HASH` format.

Followup from #187.