### PR TITLE
Fix label filter on Docker cleanup

### DIFF
--- a/internal/dockerutil/setup.go
+++ b/internal/dockerutil/setup.go
@@ -58,8 +58,10 @@ func dockerCleanup(t *testing.T, cli *client.Client) func() {
 		ctx := context.TODO()
 
 		cs, err := cli.ContainerList(ctx, types.ContainerListOptions{
-			All:     true,
-			Filters: filters.NewArgs(filters.Arg("name", t.Name())),
+			All: true,
+			Filters: filters.NewArgs(
+				filters.Arg("label", CleanupLabel+"="+t.Name()),
+			),
 		})
 		if err != nil {
 			t.Logf("Failed to list containers during docker cleanup: %v", err)


### PR DESCRIPTION
Cleaning up containers was mistakenly using a syntax that would not
match anything, causing containers to be left behind on test runs, and
breaking following tests.
