### PR TITLE
Add example test for packet forward middleware

### DIFF
--- a/examples/packet_forward_test.go
+++ b/examples/packet_forward_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestPacketForwardMiddleware(t *testing.T) {
-	t.Skip()
+	if testing.Short() {
+		t.Skip()
+	}
 
 	home := ibctest.TempDir(t)
 	client, network := ibctest.DockerSetup(t)

--- a/examples/packet_forward_test.go
+++ b/examples/packet_forward_test.go
@@ -76,6 +76,7 @@ func TestPacketForwardMiddleware(t *testing.T) {
 	channels, err := r.GetChannels(ctx, eRep, gaia.Config().ChainID)
 	require.NoError(t, err)
 
+	// Start the relayer on both paths
 	err = r.StartRelayer(ctx, eRep, pathOsmoHub)
 	require.NoError(t, err)
 
@@ -86,11 +87,11 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		func() {
 			err := r.StopRelayer(ctx, eRep)
 			if err != nil {
-				// do stuff
+				t.Logf("an error occured while stopping the relayer: %s", err)
 			}
 			for _, c := range chains {
 				if err = c.Cleanup(ctx); err != nil {
-					// do stuff
+					t.Logf("an error occured while stopping chain %s: %s", c.Config().ChainID, err)
 				}
 			}
 		},
@@ -131,11 +132,6 @@ func TestPacketForwardMiddleware(t *testing.T) {
 	secondHopDenom := transfertypes.GetPrefixedDenom(channels[1].Counterparty.PortID, channels[1].Counterparty.ChannelID, firstHopDenom)
 	dstIbcDenom := transfertypes.ParseDenomTrace(secondHopDenom)
 
-	//t.Logf("First Denom - %s \n", firstHopDenom)
-	//t.Logf("Final Denom - %s \n", tmp)
-	//t.Logf("Denom Trace - %s \n", dstIbcDenom)
-	//t.Logf("Denom Trace - %s \n", dstIbcDenom.IBCDenom())
-
 	// Check that the funds sent are present in the acc on juno
 	junoBal, err := juno.GetBalance(ctx, junoUser.Bech32Address(juno.Config().Bech32Prefix), dstIbcDenom.IBCDenom())
 	require.NoError(t, err)
@@ -167,4 +163,5 @@ func TestPacketForwardMiddleware(t *testing.T) {
 	require.Equal(t, osmosisBalOG, osmosisBal)
 
 	// Send a malformed packet with invalid receiver address from Osmosis->Hub->Juno
+
 }

--- a/examples/packet_forward_test.go
+++ b/examples/packet_forward_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestPacketForwardMiddleware(t *testing.T) {
-	t.Parallel()
+	t.Skip()
 
 	home := t.TempDir()
 	client, network := ibctest.DockerSetup(t)

--- a/examples/packet_forward_test.go
+++ b/examples/packet_forward_test.go
@@ -1,0 +1,170 @@
+package ibctest_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
+	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/test"
+	"github.com/strangelove-ventures/ibctest/testreporter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestPacketForwardMiddleware(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	client, network := ibctest.DockerSetup(t)
+
+	rep := testreporter.NewNopReporter()
+	eRep := rep.RelayerExecReporter(t)
+
+	ctx := context.Background()
+
+	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
+		{Name: "gaia", ChainName: "gaia-fork", Version: "bugfix-replace_default_transfer_with_router_module"},
+		{Name: "osmosis", ChainName: "osmosis", Version: "v7.3.0"},
+		{Name: "juno", ChainName: "juno", Version: "v6.0.0"},
+	})
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+
+	gaia, osmosis, juno := chains[0], chains[1], chains[2]
+
+	r := ibctest.NewBuiltinRelayerFactory(ibc.CosmosRly, zaptest.NewLogger(t)).Build(
+		t, client, network, home,
+	)
+
+	const pathOsmoHub = "osmohub"
+	const pathJunoHub = "junohub"
+
+	ic := ibctest.NewInterchain().
+		AddChain(osmosis).
+		AddChain(gaia).
+		AddChain(juno).
+		AddRelayer(r, "relayer").
+		AddLink(ibctest.InterchainLink{
+			Chain1:  osmosis,
+			Chain2:  gaia,
+			Relayer: r,
+			Path:    pathOsmoHub,
+		}).
+		AddLink(ibctest.InterchainLink{
+			Chain1:  gaia,
+			Chain2:  juno,
+			Relayer: r,
+			Path:    pathJunoHub,
+		})
+
+	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
+		TestName:  t.Name(),
+		HomeDir:   home,
+		Client:    client,
+		NetworkID: network,
+
+		SkipPathCreation: false,
+	}))
+
+	const userFunds = int64(10_000_000_000)
+	users := ibctest.GetAndFundTestUsers(t, ctx, t.Name(), userFunds, osmosis, gaia, juno)
+
+	channels, err := r.GetChannels(ctx, eRep, gaia.Config().ChainID)
+	require.NoError(t, err)
+
+	err = r.StartRelayer(ctx, eRep, pathOsmoHub)
+	require.NoError(t, err)
+
+	err = r.StartRelayer(ctx, eRep, pathJunoHub)
+	require.NoError(t, err)
+
+	t.Cleanup(
+		func() {
+			err := r.StopRelayer(ctx, eRep)
+			if err != nil {
+				// do stuff
+			}
+			for _, c := range chains {
+				if err = c.Cleanup(ctx); err != nil {
+					// do stuff
+				}
+			}
+		},
+	)
+
+	// Get original account balances
+	osmosisUser := users[0]
+	gaiaUser := users[1]
+	junoUser := users[2]
+
+	osmosisBalOG, err := osmosis.GetBalance(ctx, osmosisUser.Bech32Address(osmosis.Config().Bech32Prefix), osmosis.Config().Denom)
+	require.NoError(t, err)
+
+	// Send packet from Osmosis->Hub->Juno
+	// receiver format: {intermediate_refund_address}|{foward_port}/{forward_channel}:{final_destination_address}
+	const transferAmount int64 = 100000
+	receiver := fmt.Sprintf("%s|%s/%s:%s", gaiaUser.Bech32Address(gaia.Config().Bech32Prefix), channels[1].PortID, channels[1].ChannelID, junoUser.Bech32Address(juno.Config().Bech32Prefix))
+	transfer := ibc.WalletAmount{
+		Address: receiver,
+		Denom:   osmosis.Config().Denom,
+		Amount:  transferAmount,
+	}
+
+	_, err = osmosis.SendIBCTransfer(ctx, channels[0].ChannelID, osmosisUser.KeyName, transfer, nil)
+	require.NoError(t, err)
+
+	// Wait for transfer to be relayed
+	err = test.WaitForBlocks(ctx, 15, gaia)
+	require.NoError(t, err)
+
+	// Check that the funds sent are gone from the acc on osmosis
+	osmosisBal, err := osmosis.GetBalance(ctx, osmosisUser.Bech32Address(osmosis.Config().Bech32Prefix), osmosis.Config().Denom)
+	require.NoError(t, err)
+	require.Equal(t, osmosisBalOG-transferAmount, osmosisBal)
+
+	// Compose the prefixed denoms and ibc denom for asserting balances
+	firstHopDenom := transfertypes.GetPrefixedDenom(channels[0].Counterparty.PortID, channels[0].Counterparty.ChannelID, osmosis.Config().Denom)
+	secondHopDenom := transfertypes.GetPrefixedDenom(channels[1].Counterparty.PortID, channels[1].Counterparty.ChannelID, firstHopDenom)
+	dstIbcDenom := transfertypes.ParseDenomTrace(secondHopDenom)
+
+	//t.Logf("First Denom - %s \n", firstHopDenom)
+	//t.Logf("Final Denom - %s \n", tmp)
+	//t.Logf("Denom Trace - %s \n", dstIbcDenom)
+	//t.Logf("Denom Trace - %s \n", dstIbcDenom.IBCDenom())
+
+	// Check that the funds sent are present in the acc on juno
+	junoBal, err := juno.GetBalance(ctx, junoUser.Bech32Address(juno.Config().Bech32Prefix), dstIbcDenom.IBCDenom())
+	require.NoError(t, err)
+	require.Equal(t, transferAmount, junoBal)
+
+	// Send packet back from Juno->Hub->Osmosis
+	receiver = fmt.Sprintf("%s|%s/%s:%s", gaiaUser.Bech32Address(gaia.Config().Bech32Prefix), channels[0].Counterparty.PortID, channels[0].Counterparty.ChannelID, osmosisUser.Bech32Address(osmosis.Config().Bech32Prefix))
+	transfer = ibc.WalletAmount{
+		Address: receiver,
+		Denom:   dstIbcDenom.IBCDenom(),
+		Amount:  transferAmount,
+	}
+
+	_, err = juno.SendIBCTransfer(ctx, channels[1].Counterparty.ChannelID, junoUser.KeyName, transfer, nil)
+	require.NoError(t, err)
+
+	// Wait for transfer to be relayed
+	err = test.WaitForBlocks(ctx, 15, gaia)
+	require.NoError(t, err)
+
+	// Check that the funds sent are gone from the acc on juno
+	junoBal, err = juno.GetBalance(ctx, junoUser.Bech32Address(juno.Config().Bech32Prefix), dstIbcDenom.IBCDenom())
+	require.NoError(t, err)
+	require.Equal(t, int64(0), junoBal)
+
+	// Check that the funds sent are present in the acc on osmosis
+	osmosisBal, err = osmosis.GetBalance(ctx, osmosisUser.Bech32Address(osmosis.Config().Bech32Prefix), osmosis.Config().Denom)
+	require.NoError(t, err)
+	require.Equal(t, osmosisBalOG, osmosisBal)
+
+	// Send a malformed packet with invalid receiver address from Osmosis->Hub->Juno
+}

--- a/examples/packet_forward_test.go
+++ b/examples/packet_forward_test.go
@@ -17,7 +17,7 @@ import (
 func TestPacketForwardMiddleware(t *testing.T) {
 	t.Skip()
 
-	home := t.TempDir()
+	home := ibctest.TempDir(t)
 	client, network := ibctest.DockerSetup(t)
 
 	rep := testreporter.NewNopReporter()


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR adds a standalone test, for the IBC [packet-forward-middleware](https://github.com/strangelove-ventures/packet-forward-middleware), to an `examples` directory.

The test asserts that token transfers work in both directions using the middleware and also has the funds returned to the appropriate address in the case of one hop failing.

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project

