### PR TITLE
Use empty entrypoint in every ContainerCreate call

### DIFF
--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -232,7 +232,7 @@ func (p *PenumbraAppNode) SendIBCTransfer(ctx context.Context, channelID, keyNam
 }
 
 func (p *PenumbraAppNode) CreateNodeContainer(ctx context.Context) error {
-  cmd := []string{"pd", "start", "--host", "0.0.0.0", "-r", p.HomeDir()}
+	cmd := []string{"pd", "start", "--host", "0.0.0.0", "-r", p.HomeDir()}
 	fmt.Printf("{%s} -> '%s'\n", p.Name(), strings.Join(cmd, " "))
 
 	cc, err := p.DockerClient.ContainerCreate(
@@ -240,7 +240,8 @@ func (p *PenumbraAppNode) CreateNodeContainer(ctx context.Context) error {
 		&container.Config{
 			Image: p.Image.Ref(),
 
-			Cmd: cmd,
+			Entrypoint: []string{},
+			Cmd:        cmd,
 
 			Hostname: p.HostName(),
 			User:     dockerutil.GetRootUserString(),

--- a/internal/dockerutil/image.go
+++ b/internal/dockerutil/image.go
@@ -154,8 +154,8 @@ func (image *Image) createContainer(ctx context.Context, containerName, hostName
 		&container.Config{
 			Image: image.imageRef(),
 
-			// Entrypoint: []string{}, // Wasn't present before?
-			Cmd: cmd,
+			Entrypoint: []string{},
+			Cmd:        cmd,
 
 			Env: opts.Env,
 


### PR DESCRIPTION
The entrypoint was unspecified in two ContainerCreate calls, resulting
in the possibility of being unable to construct custom commands.

Closes #183.
