### PR TITLE
Include stdout and stderr on failed Docker job error

### DIFF
--- a/internal/dockerutil/errors.go
+++ b/internal/dockerutil/errors.go
@@ -2,12 +2,12 @@ package dockerutil
 
 import "fmt"
 
-func HandleNodeJobError(exitCode int, _, _ string, err error) error {
+func HandleNodeJobError(exitCode int, stdout, stderr string, err error) error {
 	if err != nil {
 		return err
 	}
 	if exitCode != 0 {
-		return fmt.Errorf("container returned non-zero error code: %d", exitCode)
+		return fmt.Errorf("container returned non-zero error code: %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
 	}
 	return nil
 }


### PR DESCRIPTION
I end up often making this change by hand when I get an obscure error on
an unexpected non-zero exit code. Adding it here once and for all.
