### PR TITLE
refactor: Interface{} to any

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -889,11 +889,11 @@ func (tn *ChainNode) QueryICA(ctx context.Context, connectionID, address string)
 // SendICABankTransfer builds a bank transfer message for a specified address and sends it to the specified
 // interchain account.
 func (tn *ChainNode) SendICABankTransfer(ctx context.Context, connectionID, fromAddr string, amount ibc.WalletAmount) error {
-	msg, err := json.Marshal(map[string]interface{}{
+	msg, err := json.Marshal(map[string]any{
 		"@type":        "/cosmos.bank.v1beta1.MsgSend",
 		"from_address": fromAddr,
 		"to_address":   amount.Address,
-		"amount": []map[string]interface{}{
+		"amount": []map[string]any{
 			{
 				"denom":  amount.Denom,
 				"amount": amount.Amount,

--- a/internal/blockdb/chain.go
+++ b/internal/blockdb/chain.go
@@ -31,7 +31,7 @@ func (txs transactions) Hash() []byte {
 // The txs should be human-readable.
 func (chain *Chain) SaveBlock(ctx context.Context, height uint64, txs []Tx) error {
 	k := fmt.Sprintf("%d-%x", height, transactions(txs).Hash())
-	_, err, _ := chain.single.Do(k, func() (interface{}, error) {
+	_, err, _ := chain.single.Do(k, func() (any, error) {
 		return nil, chain.saveBlock(ctx, height, txs)
 	})
 	return err

--- a/internal/blockdb/tui/presenter/tx.go
+++ b/internal/blockdb/tui/presenter/tx.go
@@ -9,7 +9,7 @@ import (
 	"github.com/strangelove-ventures/ibctest/internal/blockdb"
 )
 
-var bufPool = sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
+var bufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
 
 type Tx struct {
 	Result blockdb.TxResult
@@ -42,7 +42,7 @@ func (txs Txs) ToJSON() []byte {
 		Height int64
 		Tx     []byte
 	}
-	objs := make([]interface{}, len(txs))
+	objs := make([]any, len(txs))
 	for i, tx := range txs {
 		if !json.Valid(tx.Tx) {
 			objs[i] = jsonBytes{

--- a/internal/blockdb/tui/update_test.go
+++ b/internal/blockdb/tui/update_test.go
@@ -198,7 +198,7 @@ func TestModel_Update(t *testing.T) {
 
 		require.NotEmpty(t, gotText)
 
-		var gotTxs []interface{}
+		var gotTxs []any
 		require.NoError(t, json.Unmarshal([]byte(gotText), &gotTxs))
 		require.Len(t, gotTxs, 2)
 

--- a/tempdir.go
+++ b/tempdir.go
@@ -17,8 +17,8 @@ type TempDirTestingT interface {
 	Failed() bool
 	Cleanup(func())
 
-	Logf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
+	Logf(format string, args ...any)
+	Errorf(format string, args ...any)
 }
 
 // KeepTempDirOnFailure determines whether a directory created by TempDir

--- a/tempdir_test.go
+++ b/tempdir_test.go
@@ -48,11 +48,11 @@ func (t *mockTempT) RunCleanups() {
 	t.cleanups = nil
 }
 
-func (t *mockTempT) Logf(format string, args ...interface{}) {
+func (t *mockTempT) Logf(format string, args ...any) {
 	t.logs = append(t.logs, fmt.Sprintf(format, args...))
 }
 
-func (t *mockTempT) Errorf(format string, args ...interface{}) {
+func (t *mockTempT) Errorf(format string, args ...any) {
 	t.errors = append(t.errors, fmt.Sprintf(format, args...))
 }
 

--- a/test/poll_for_state.go
+++ b/test/poll_for_state.go
@@ -55,7 +55,7 @@ type blockPoller struct {
 	pollErr       *pollError
 }
 
-func (p blockPoller) doPoll(ctx context.Context, startHeight, maxHeight uint64, packet ibc.Packet) (interface{}, error) {
+func (p blockPoller) doPoll(ctx context.Context, startHeight, maxHeight uint64, packet ibc.Packet) (any, error) {
 	if maxHeight < startHeight {
 		panic("maxHeight must be greater than or equal to startHeight")
 	}
@@ -72,7 +72,7 @@ func (p blockPoller) doPoll(ctx context.Context, startHeight, maxHeight uint64, 
 		}
 
 		var (
-			found   interface{}
+			found   any
 			findErr error
 		)
 		switch {
@@ -135,7 +135,7 @@ func (pe *pollError) SetErr(err error) {
 	pe.error = err
 }
 
-func (pe *pollError) PushSearched(packet interface{}) {
+func (pe *pollError) PushSearched(packet any) {
 	pe.searchedPackets = append(pe.searchedPackets, spew.Sdump(packet))
 }
 

--- a/testreporter/reporter.go
+++ b/testreporter/reporter.go
@@ -15,7 +15,7 @@ type T interface {
 	Name() string
 	Cleanup(func())
 
-	Skip(...interface{})
+	Skip(...any)
 
 	Parallel()
 
@@ -137,7 +137,7 @@ func (r *Reporter) TrackParallel(t T) {
 
 // TrackSkip records a the reason for a test being skipped,
 // and calls t.Skip.
-func (r *Reporter) TrackSkip(t T, format string, args ...interface{}) {
+func (r *Reporter) TrackSkip(t T, format string, args ...any) {
 	now := time.Now()
 	msg := fmt.Sprintf(format, args...)
 
@@ -201,7 +201,7 @@ func (r *Reporter) TestifyT(t TestifyT) *TestifyReporter {
 type TestifyT interface {
 	Name() string
 
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	FailNow()
 }
 
@@ -214,7 +214,7 @@ type TestifyReporter struct {
 
 // Errorf records the error message in r's Reporter
 // and then passes through to r's underlying TestifyT.
-func (r *TestifyReporter) Errorf(format string, args ...interface{}) {
+func (r *TestifyReporter) Errorf(format string, args ...any) {
 	now := time.Now()
 
 	r.r.in <- TestErrorMessage{

--- a/testreporter/reporter_test.go
+++ b/testreporter/reporter_test.go
@@ -52,11 +52,11 @@ func (t *mockT) RunCleanups() {
 	}
 }
 
-func (t *mockT) Errorf(format string, args ...interface{}) {
+func (t *mockT) Errorf(format string, args ...any) {
 	t.errors = append(t.errors, fmt.Sprintf(format, args...))
 }
 
-func (t *mockT) Skip(args ...interface{}) {
+func (t *mockT) Skip(args ...any) {
 	t.skips = append(t.skips, fmt.Sprint(args...))
 	t.skipped = true
 }


### PR DESCRIPTION
```
gofmt -w -r 'interface{} -> any' .
```

This may make use of build tags tricky if we ever need to go that route to support ibc-go multiple versions. 

But the inverse is easy:

```
gofmt -w -r 'any -> interface{}' .
```