### PR TITLE
Use docker to retrieve genesis hashes

### DIFF
--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -418,7 +418,7 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 		}
 	}
 
-	if err := c.ChainNodes.LogGenesisHashes(); err != nil {
+	if err := c.ChainNodes.LogGenesisHashes(ctx); err != nil {
 		return err
 	}
 

--- a/internal/dockerutil/fileretriever.go
+++ b/internal/dockerutil/fileretriever.go
@@ -1,0 +1,146 @@
+package dockerutil
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"go.uber.org/zap"
+)
+
+// FileRetriever allows retrieving a single file from a Docker volume.
+// In the future it may allow retrieving an entire directory.
+type FileRetriever struct {
+	log *zap.Logger
+
+	cli *client.Client
+
+	testName string
+}
+
+// NewFileRetriever returns a new FileRetriever.
+func NewFileRetriever(log *zap.Logger, cli *client.Client, testName string) *FileRetriever {
+	return &FileRetriever{log: log, cli: cli, testName: testName}
+}
+
+// SingleFileContent returns the content of the file named at relPath,
+// inside the volume specified by volumeName.
+func (r *FileRetriever) SingleFileContent(ctx context.Context, volumeName, relPath string) ([]byte, error) {
+	const mountPath = "/mnt/dockervolume"
+
+	if err := ensureBusybox(ctx, r.cli); err != nil {
+		return nil, err
+	}
+
+	containerName := fmt.Sprintf("ibctest-getfile-%d-%s", time.Now().UnixNano(), RandLowerCaseLetterString(5))
+
+	cc, err := r.cli.ContainerCreate(
+		ctx,
+		&container.Config{
+			Image: busyboxRef,
+
+			// Use root user to avoid permission issues when reading files from the volume.
+			User: GetRootUserString(),
+
+			Labels: map[string]string{CleanupLabel: r.testName},
+		},
+		&container.HostConfig{
+			Binds:      []string{volumeName + ":" + mountPath},
+			AutoRemove: true,
+		},
+		nil, // No networking necessary.
+		nil,
+		containerName,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating container: %w", err)
+	}
+
+	defer func() {
+		if err := r.cli.ContainerRemove(ctx, cc.ID, types.ContainerRemoveOptions{
+			Force: true,
+		}); err != nil {
+			r.log.Warn("Failed to remove file content container", zap.String("container_id", cc.ID), zap.Error(err))
+		}
+	}()
+
+	rc, _, err := r.cli.CopyFromContainer(ctx, cc.ID, path.Join(mountPath, relPath))
+	if err != nil {
+		return nil, fmt.Errorf("copying from container: %w", err)
+	}
+	defer func() {
+		_ = rc.Close()
+	}()
+
+	wantPath := path.Base(relPath)
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading tar from container: %w", err)
+		}
+		if hdr.Name != wantPath {
+			r.log.Debug("Unexpected path", zap.String("want", relPath), zap.String("got", hdr.Name))
+			continue
+		}
+
+		return io.ReadAll(tr)
+	}
+
+	return nil, fmt.Errorf("path %q not found in tar from container", relPath)
+}
+
+// Allow multiple goroutines to check for busybox
+// by using a protected package-level variable.
+//
+// A mutex allows for retries upon error, if we ever need that;
+// whereas a sync.Once would not be simple to retry.
+var (
+	ensureBusyboxMu sync.Mutex
+	hasBusybox      bool
+)
+
+const busyboxRef = "busybox:stable"
+
+func ensureBusybox(ctx context.Context, cli *client.Client) error {
+	ensureBusyboxMu.Lock()
+	defer ensureBusyboxMu.Unlock()
+
+	if hasBusybox {
+		return nil
+	}
+
+	images, err := cli.ImageList(ctx, types.ImageListOptions{
+		Filters: filters.NewArgs(filters.Arg("reference", busyboxRef)),
+	})
+	if err != nil {
+		return fmt.Errorf("listing images to check busybox presence: %w", err)
+	}
+
+	if len(images) > 0 {
+		hasBusybox = true
+		return nil
+	}
+
+	rc, err := cli.ImagePull(ctx, busyboxRef, types.ImagePullOptions{})
+	if err != nil {
+		return err
+	}
+
+	_, _ = io.Copy(io.Discard, rc)
+	_ = rc.Close()
+
+	hasBusybox = true
+	return nil
+}

--- a/internal/dockerutil/fileretriever_test.go
+++ b/internal/dockerutil/fileretriever_test.go
@@ -1,0 +1,63 @@
+package dockerutil_test
+
+import (
+	"context"
+	"testing"
+
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/internal/dockerutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestFileRetriever(t *testing.T) {
+	t.Parallel()
+
+	cli, network := ibctest.DockerSetup(t)
+
+	ctx := context.Background()
+	v, err := cli.VolumeCreate(ctx, volumetypes.VolumeCreateBody{
+		Labels: map[string]string{dockerutil.CleanupLabel: t.Name()},
+	})
+	require.NoError(t, err)
+
+	img := dockerutil.NewImage(
+		zaptest.NewLogger(t),
+		cli,
+		network,
+		t.Name(),
+		"busybox", "stable",
+	)
+
+	_, _, err = img.Run(
+		ctx,
+		[]string{"sh", "-c", "printf 'hello world' > /mnt/test/hello.txt"},
+		dockerutil.ContainerOptions{
+			Binds: []string{v.Name + ":/mnt/test"},
+		},
+	)
+	require.NoError(t, err)
+	_, _, err = img.Run(
+		ctx,
+		[]string{"sh", "-c", "mkdir -p /mnt/test/foo/bar/ && printf 'test' > /mnt/test/foo/bar/baz.txt"},
+		dockerutil.ContainerOptions{
+			Binds: []string{v.Name + ":/mnt/test"},
+		},
+	)
+	require.NoError(t, err)
+
+	fr := dockerutil.NewFileRetriever(zaptest.NewLogger(t), cli, t.Name())
+
+	t.Run("top-level file", func(t *testing.T) {
+		b, err := fr.SingleFileContent(ctx, v.Name, "hello.txt")
+		require.NoError(t, err)
+		require.Equal(t, string(b), "hello world")
+	})
+
+	t.Run("nested file", func(t *testing.T) {
+		b, err := fr.SingleFileContent(ctx, v.Name, "foo/bar/baz.txt")
+		require.NoError(t, err)
+		require.Equal(t, string(b), "test")
+	})
+}

--- a/internal/dockerutil/fileretriever_test.go
+++ b/internal/dockerutil/fileretriever_test.go
@@ -39,6 +39,7 @@ func TestFileRetriever(t *testing.T) {
 		[]string{"sh", "-c", "chmod 0700 /mnt/test && printf 'hello world' > /mnt/test/hello.txt"},
 		dockerutil.ContainerOptions{
 			Binds: []string{v.Name + ":/mnt/test"},
+			User:  dockerutil.GetRootUserString(),
 		},
 	)
 	require.NoError(t, err)
@@ -47,6 +48,7 @@ func TestFileRetriever(t *testing.T) {
 		[]string{"sh", "-c", "mkdir -p /mnt/test/foo/bar/ && printf 'test' > /mnt/test/foo/bar/baz.txt"},
 		dockerutil.ContainerOptions{
 			Binds: []string{v.Name + ":/mnt/test"},
+			User:  dockerutil.GetRootUserString(),
 		},
 	)
 	require.NoError(t, err)

--- a/internal/dockerutil/fileretriever_test.go
+++ b/internal/dockerutil/fileretriever_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestFileRetriever(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping due to short mode")
+	}
+
 	t.Parallel()
 
 	cli, network := ibctest.DockerSetup(t)
@@ -32,7 +36,7 @@ func TestFileRetriever(t *testing.T) {
 
 	_, _, err = img.Run(
 		ctx,
-		[]string{"sh", "-c", "printf 'hello world' > /mnt/test/hello.txt"},
+		[]string{"sh", "-c", "chmod 0700 /mnt/test && printf 'hello world' > /mnt/test/hello.txt"},
 		dockerutil.ContainerOptions{
 			Binds: []string{v.Name + ":/mnt/test"},
 		},


### PR DESCRIPTION
This is one step towards #200, using ephemeral containers to read the
genesis file content from the docker volume instead of reading from the
host disk.

Note that as of this commit, the docker volume is still a host mount,
but it should be seamless to switch this usage to a volume once
everything else for #200 is in place.