### PR TITLE
fix: Remove superflous container stop

### DIFF
--- a/internal/dockerutil/image.go
+++ b/internal/dockerutil/image.go
@@ -96,11 +96,6 @@ func (image *Image) Run(ctx context.Context, cmd []string, opts ContainerOptions
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() {
-		if err := c.Stop(10 * time.Second); err != nil {
-			c.log.Error("Failed to stop container", zap.Error(err))
-		}
-	}()
 	return c.Wait(ctx)
 }
 


### PR DESCRIPTION
I feel like this is the 3rd time I've tried to remove this superflous code. 

I think I've had other branches that never merged into main but I thought they did. 

In any case, hope to resolve this once and for all. 😆 