### PR TITLE
Use Docker API to copy genesis files to all nodes

### DIFF
--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -407,13 +407,13 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 		return err
 	}
 
-	genbz, err := os.ReadFile(validator0.GenesisFilePath())
+	genbz, err := validator0.genesisFileContent(ctx)
 	if err != nil {
 		return err
 	}
 
-	for i := 1; i < len(c.ChainNodes); i++ {
-		if err := os.WriteFile(c.ChainNodes[i].GenesisFilePath(), genbz, 0644); err != nil { //nolint
+	for _, cn := range c.ChainNodes[1:] {
+		if err := cn.overwriteGenesisFile(ctx, genbz); err != nil {
 			return err
 		}
 	}

--- a/internal/dockerutil/filewriter.go
+++ b/internal/dockerutil/filewriter.go
@@ -1,0 +1,106 @@
+package dockerutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"go.uber.org/zap"
+)
+
+// FileWriter allows retrieving a single file from a Docker volume.
+// In the future it may allow retrieving an entire directory.
+type FileWriter struct {
+	log *zap.Logger
+
+	cli *client.Client
+
+	testName string
+}
+
+// NewFileWriter returns a new FileWriter.
+func NewFileWriter(log *zap.Logger, cli *client.Client, testName string) *FileWriter {
+	return &FileWriter{log: log, cli: cli, testName: testName}
+}
+
+// WriteFile writes the single file containing content, at relPath within the given volume.
+func (w *FileWriter) WriteFile(ctx context.Context, volumeName, relPath string, content []byte) error {
+	const mountPath = "/mnt/dockervolume"
+
+	if err := ensureBusybox(ctx, w.cli); err != nil {
+		return err
+	}
+
+	containerName := fmt.Sprintf("ibctest-writefile-%d-%s", time.Now().UnixNano(), RandLowerCaseLetterString(5))
+
+	cc, err := w.cli.ContainerCreate(
+		ctx,
+		&container.Config{
+			Image: busyboxRef,
+
+			// No entrypoint or command specified because we are not starting the container.
+
+			// Use root user to avoid permission issues when reading files from the volume.
+			User: GetRootUserString(),
+
+			Labels: map[string]string{CleanupLabel: w.testName},
+		},
+		&container.HostConfig{
+			Binds:      []string{volumeName + ":" + mountPath},
+			AutoRemove: true,
+		},
+		nil, // No networking necessary.
+		nil,
+		containerName,
+	)
+	if err != nil {
+		return fmt.Errorf("creating container: %w", err)
+	}
+
+	defer func() {
+		if err := w.cli.ContainerRemove(ctx, cc.ID, types.ContainerRemoveOptions{
+			Force: true,
+		}); err != nil {
+			w.log.Warn("Failed to remove file content container", zap.String("container_id", cc.ID), zap.Error(err))
+		}
+	}()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: relPath,
+
+		Size: int64(len(content)),
+		Mode: 0600,
+		// Omitting Uname for now; I think docker keeps existing user details for files that exist already.
+
+		ModTime: time.Now(),
+
+		Format: tar.FormatPAX,
+	}); err != nil {
+		return fmt.Errorf("writing tar header: %w", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		return fmt.Errorf("writing content to tar: %w", err)
+	}
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("closing tar writer: %w", err)
+	}
+
+	if err := w.cli.CopyToContainer(
+		ctx,
+		cc.ID,
+		mountPath,
+		&buf,
+		types.CopyToContainerOptions{},
+	); err != nil {
+		return fmt.Errorf("copying tar to container: %w", err)
+	}
+
+	return nil
+}

--- a/internal/dockerutil/filewriter_test.go
+++ b/internal/dockerutil/filewriter_test.go
@@ -1,0 +1,68 @@
+package dockerutil_test
+
+import (
+	"context"
+	"testing"
+
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/internal/dockerutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestFileWriter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping due to short mode")
+	}
+
+	t.Parallel()
+
+	cli, network := ibctest.DockerSetup(t)
+
+	ctx := context.Background()
+	v, err := cli.VolumeCreate(ctx, volumetypes.VolumeCreateBody{
+		Labels: map[string]string{dockerutil.CleanupLabel: t.Name()},
+	})
+	require.NoError(t, err)
+
+	img := dockerutil.NewImage(
+		zaptest.NewLogger(t),
+		cli,
+		network,
+		t.Name(),
+		"busybox", "stable",
+	)
+
+	fw := dockerutil.NewFileWriter(zaptest.NewLogger(t), cli, t.Name())
+
+	t.Run("top-level file", func(t *testing.T) {
+		require.NoError(t, fw.WriteFile(context.Background(), v.Name, "hello.txt", []byte("hello world")))
+		stdout, _, err := img.Run(
+			ctx,
+			[]string{"sh", "-c", "cat /mnt/test/hello.txt"},
+			dockerutil.ContainerOptions{
+				Binds: []string{v.Name + ":/mnt/test"},
+				User:  dockerutil.GetRootUserString(),
+			},
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, string(stdout), "hello world")
+	})
+
+	t.Run("create nested file", func(t *testing.T) {
+		require.NoError(t, fw.WriteFile(context.Background(), v.Name, "a/b/c/d.txt", []byte(":D")))
+		stdout, _, err := img.Run(
+			ctx,
+			[]string{"sh", "-c", "cat /mnt/test/a/b/c/d.txt"},
+			dockerutil.ContainerOptions{
+				Binds: []string{v.Name + ":/mnt/test"},
+				User:  dockerutil.GetRootUserString(),
+			},
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, string(stdout), ":D")
+	})
+}


### PR DESCRIPTION
This is another step in avoiding modifying files on the host, in support
of #200.