### PR TITLE
Extract SetVolumeOwner function in dockerutil

### DIFF
--- a/internal/dockerutil/busybox.go
+++ b/internal/dockerutil/busybox.go
@@ -1,0 +1,56 @@
+package dockerutil
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+)
+
+// Allow multiple goroutines to check for busybox
+// by using a protected package-level variable.
+//
+// A mutex allows for retries upon error, if we ever need that;
+// whereas a sync.Once would not be simple to retry.
+var (
+	ensureBusyboxMu sync.Mutex
+	hasBusybox      bool
+)
+
+const busyboxRef = "busybox:stable"
+
+func ensureBusybox(ctx context.Context, cli *client.Client) error {
+	ensureBusyboxMu.Lock()
+	defer ensureBusyboxMu.Unlock()
+
+	if hasBusybox {
+		return nil
+	}
+
+	images, err := cli.ImageList(ctx, types.ImageListOptions{
+		Filters: filters.NewArgs(filters.Arg("reference", busyboxRef)),
+	})
+	if err != nil {
+		return fmt.Errorf("listing images to check busybox presence: %w", err)
+	}
+
+	if len(images) > 0 {
+		hasBusybox = true
+		return nil
+	}
+
+	rc, err := cli.ImagePull(ctx, busyboxRef, types.ImagePullOptions{})
+	if err != nil {
+		return err
+	}
+
+	_, _ = io.Copy(io.Discard, rc)
+	_ = rc.Close()
+
+	hasBusybox = true
+	return nil
+}

--- a/internal/dockerutil/fileretriever.go
+++ b/internal/dockerutil/fileretriever.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"io"
 	"path"
-	"sync"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"go.uber.org/zap"
 )
@@ -99,48 +97,4 @@ func (r *FileRetriever) SingleFileContent(ctx context.Context, volumeName, relPa
 	}
 
 	return nil, fmt.Errorf("path %q not found in tar from container", relPath)
-}
-
-// Allow multiple goroutines to check for busybox
-// by using a protected package-level variable.
-//
-// A mutex allows for retries upon error, if we ever need that;
-// whereas a sync.Once would not be simple to retry.
-var (
-	ensureBusyboxMu sync.Mutex
-	hasBusybox      bool
-)
-
-const busyboxRef = "busybox:stable"
-
-func ensureBusybox(ctx context.Context, cli *client.Client) error {
-	ensureBusyboxMu.Lock()
-	defer ensureBusyboxMu.Unlock()
-
-	if hasBusybox {
-		return nil
-	}
-
-	images, err := cli.ImageList(ctx, types.ImageListOptions{
-		Filters: filters.NewArgs(filters.Arg("reference", busyboxRef)),
-	})
-	if err != nil {
-		return fmt.Errorf("listing images to check busybox presence: %w", err)
-	}
-
-	if len(images) > 0 {
-		hasBusybox = true
-		return nil
-	}
-
-	rc, err := cli.ImagePull(ctx, busyboxRef, types.ImagePullOptions{})
-	if err != nil {
-		return err
-	}
-
-	_, _ = io.Copy(io.Discard, rc)
-	_ = rc.Close()
-
-	hasBusybox = true
-	return nil
 }

--- a/internal/dockerutil/filewriter.go
+++ b/internal/dockerutil/filewriter.go
@@ -44,7 +44,6 @@ func (w *FileWriter) WriteFile(ctx context.Context, volumeName, relPath string, 
 		&container.Config{
 			Image: busyboxRef,
 
-			// No entrypoint or command specified because we are not starting the container.
 			Entrypoint: []string{"sh", "-c"},
 			Cmd: []string{
 				// Take the uid and gid of the mount path,

--- a/internal/dockerutil/volumeowner.go
+++ b/internal/dockerutil/volumeowner.go
@@ -1,0 +1,110 @@
+package dockerutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"go.uber.org/zap"
+)
+
+// VolumeOwnerOptions contain the configuration for the SetVolumeOwner function.
+type VolumeOwnerOptions struct {
+	Log *zap.Logger
+
+	Client *client.Client
+
+	VolumeName string
+	ImageRef   string
+	TestName   string
+}
+
+// SetVolumeOwner configures the owner of a volume to match the default user in the supplied image reference.
+func SetVolumeOwner(ctx context.Context, opts VolumeOwnerOptions) error {
+	ii, _, err := opts.Client.ImageInspectWithRaw(ctx, opts.ImageRef)
+	if err != nil {
+		return fmt.Errorf("inspecting image %q: %w", opts.ImageRef, err)
+	}
+
+	// Unclear guidance on the difference between the Config and ContainerConfig fields:
+	// https://forums.docker.com/t/what-is-the-difference-between-containerconfig-and-config-in-image/83232
+	// https://stackoverflow.com/q/36216220
+	// Assuming Config is more pertinent.
+	u := ii.Config.User
+
+	// Start a one-off container to chmod and chown the volume.
+
+	containerName := fmt.Sprintf("ibctest-volumeowner-%d-%s", time.Now().UnixNano(), RandLowerCaseLetterString(5))
+
+	const mountPath = "/mnt/dockervolume"
+	cc, err := opts.Client.ContainerCreate(
+		ctx,
+		&container.Config{
+			Image: opts.ImageRef, // Using the original image so the owner is present.
+
+			Entrypoint: []string{"sh", "-c"},
+			Cmd: []string{
+				`chown "$2" "$1" && chmod 0700 "$1"`,
+				"_", // Meaningless arg0 for sh -c with positional args.
+				mountPath,
+				u,
+			},
+
+			// Root user so we have permissions to set ownership and mode.
+			User: GetRootUserString(),
+
+			Labels: map[string]string{CleanupLabel: opts.TestName},
+		},
+		&container.HostConfig{
+			Binds:      []string{opts.VolumeName + ":" + mountPath},
+			AutoRemove: true,
+		},
+		nil, // No networking necessary.
+		nil,
+		containerName,
+	)
+	if err != nil {
+		return fmt.Errorf("creating container: %w", err)
+	}
+
+	autoRemoved := false
+	defer func() {
+		if autoRemoved {
+			// No need to attempt removing the container if we successfully started and waited for it to complete.
+			return
+		}
+
+		if err := opts.Client.ContainerRemove(ctx, cc.ID, types.ContainerRemoveOptions{
+			Force: true,
+		}); err != nil {
+			opts.Log.Warn("Failed to remove volume-owner container", zap.String("container_id", cc.ID), zap.Error(err))
+		}
+	}()
+
+	if err := opts.Client.ContainerStart(ctx, cc.ID, types.ContainerStartOptions{}); err != nil {
+		return fmt.Errorf("starting volume-owner container: %w", err)
+	}
+
+	waitCh, errCh := opts.Client.ContainerWait(ctx, cc.ID, container.WaitConditionNotRunning)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	case res := <-waitCh:
+		autoRemoved = true
+
+		if res.Error != nil {
+			return fmt.Errorf("waiting for volume-owner container: %s", res.Error.Message)
+		}
+
+		if res.StatusCode != 0 {
+			return fmt.Errorf("configuring volume exited %d", res.StatusCode)
+		}
+	}
+
+	return nil
+}

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -95,7 +95,15 @@ func NewDockerRelayer(ctx context.Context, log *zap.Logger, testName string, cli
 	// but we configure the relayer to run as a non-root user,
 	// so set the node home (where the volume is mounted) to be owned
 	// by the relayer user.
-	if err := r.chownNodeHome(ctx); err != nil {
+	if err := dockerutil.SetVolumeOwner(ctx, dockerutil.VolumeOwnerOptions{
+		Log: r.log,
+
+		Client: r.client,
+
+		VolumeName: r.volumeName,
+		ImageRef:   containerImage.Ref(),
+		TestName:   testName,
+	}); err != nil {
 		return nil, fmt.Errorf("chown node home: %w", err)
 	}
 
@@ -113,20 +121,6 @@ func NewDockerRelayer(ctx context.Context, log *zap.Logger, testName string, cli
 	}
 
 	return &r, nil
-}
-
-func (r *DockerRelayer) chownNodeHome(ctx context.Context) error {
-	return r.runOneOff(ctx, oneOffOptions{
-		ContainerNameDetail: "chown",
-		Entrypoint:          []string{"sh", "-c"},
-		Cmd: []string{
-			fmt.Sprintf(
-				"chown -R %s %s && chmod 0700 %s",
-				r.c.DockerUser(), r.NodeHome(), r.NodeHome(),
-			),
-		},
-		User: dockerutil.GetRootUserString(),
-	})
 }
 
 func (r *DockerRelayer) AddChainConfiguration(ctx context.Context, rep ibc.RelayerExecReporter, chainConfig ibc.ChainConfig, keyName, rpcAddr, grpcAddr string) error {


### PR DESCRIPTION
This behavior already existed internally in the relayer docker
boilerplate; extract it to a standalone function in the dockerutil
package so that it can be used more generally, in an upcoming change to
use volumes for cosmos chain containers.

Also move the busybox helpers to their own file.