### PR TITLE
Use Docker volumes for cosmos chains

### DIFF
--- a/chain/cosmos/broadcaster.go
+++ b/chain/cosmos/broadcaster.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -97,7 +97,7 @@ func (b *Broadcaster) GetClientContext(ctx context.Context, user broadcast.User)
 	_, ok := b.keyrings[user]
 	if !ok {
 		localDir := b.t.TempDir()
-		containerKeyringDir := filepath.Join(cn.HomeDir(), "keyring-test")
+		containerKeyringDir := path.Join(cn.HomeDir(), "keyring-test")
 		kr, err := dockerutil.NewLocalKeyringFromDockerContainer(ctx, cn.DockerClient, localDir, containerKeyringDir, cn.containerID)
 		if err != nil {
 			return client.Context{}, err
@@ -150,9 +150,10 @@ func (b *Broadcaster) defaultClientContext(fromUser broadcast.User, sdkAdd sdk.A
 		WithAccountRetriever(authtypes.AccountRetriever{}).
 		WithKeyring(kr).
 		WithBroadcastMode(flags.BroadcastBlock).
-		WithCodec(defaultEncoding.Marshaler).
-		WithHomeDir(cn.Home)
+		WithCodec(defaultEncoding.Marshaler)
 
+	// NOTE: the returned context used to have .WithHomeDir(cn.Home),
+	// but that field no longer exists and the test against Broadcaster still passes without it.
 }
 
 // defaultTxFactory creates a new Factory with default configuration.

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -701,7 +701,6 @@ func (tn *ChainNode) CreateNodeContainer(ctx context.Context) error {
 			Cmd:        cmd,
 
 			Hostname: tn.HostName(),
-			User:     dockerutil.GetDockerUserString(),
 
 			Labels: map[string]string{dockerutil.CleanupLabel: tn.TestName},
 

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -40,7 +40,7 @@ import (
 
 // ChainNode represents a node in the test network that is being created
 type ChainNode struct {
-	Home         string
+	VolumeName   string
 	Index        int
 	Chain        ibc.Chain
 	Validator    bool
@@ -124,21 +124,9 @@ func (tn *ChainNode) HostName() string {
 	return dockerutil.CondenseHostName(tn.Name())
 }
 
-// Dir is the directory where the test node files are stored
-func (tn *ChainNode) Dir() string {
-	return filepath.Join(tn.Home, tn.Name())
-}
-
-// MkDir creates the directory for the testnode
-func (tn *ChainNode) MkDir() {
-	if err := os.MkdirAll(tn.Dir(), 0755); err != nil {
-		panic(err)
-	}
-}
-
 func (tn *ChainNode) genesisFileContent(ctx context.Context) ([]byte, error) {
 	fr := dockerutil.NewFileRetriever(tn.logger(), tn.DockerClient, tn.TestName)
-	gen, err := fr.SingleFileContent(ctx, tn.Dir(), "config/genesis.json")
+	gen, err := fr.SingleFileContent(ctx, tn.VolumeName, "config/genesis.json")
 	if err != nil {
 		return nil, fmt.Errorf("getting genesis.json content: %w", err)
 	}
@@ -148,7 +136,7 @@ func (tn *ChainNode) genesisFileContent(ctx context.Context) ([]byte, error) {
 
 func (tn *ChainNode) overwriteGenesisFile(ctx context.Context, content []byte) error {
 	fw := dockerutil.NewFileWriter(tn.logger(), tn.DockerClient, tn.TestName)
-	if err := fw.WriteFile(ctx, tn.Dir(), "config/genesis.json", content); err != nil {
+	if err := fw.WriteFile(ctx, tn.VolumeName, "config/genesis.json", content); err != nil {
 		return fmt.Errorf("overwriting genesis.json: %w", err)
 	}
 
@@ -164,13 +152,13 @@ func (tn *ChainNode) copyGentx(ctx context.Context, destVal *ChainNode) error {
 	relPath := fmt.Sprintf("config/gentx/gentx-%s.json", nid)
 
 	fr := dockerutil.NewFileRetriever(tn.logger(), tn.DockerClient, tn.TestName)
-	gentx, err := fr.SingleFileContent(ctx, tn.Dir(), relPath)
+	gentx, err := fr.SingleFileContent(ctx, tn.VolumeName, relPath)
 	if err != nil {
 		return fmt.Errorf("getting gentx content: %w", err)
 	}
 
 	fw := dockerutil.NewFileWriter(destVal.logger(), destVal.DockerClient, destVal.TestName)
-	if err := fw.WriteFile(ctx, destVal.Dir(), relPath, gentx); err != nil {
+	if err := fw.WriteFile(ctx, destVal.VolumeName, relPath, gentx); err != nil {
 		return fmt.Errorf("overwriting gentx: %w", err)
 	}
 
@@ -190,11 +178,11 @@ type PrivValidatorKeyFile struct {
 
 // Bind returns the home folder bind point for running the node
 func (tn *ChainNode) Bind() []string {
-	return []string{fmt.Sprintf("%s:%s", tn.Dir(), tn.HomeDir())}
+	return []string{fmt.Sprintf("%s:%s", tn.VolumeName, tn.HomeDir())}
 }
 
 func (tn *ChainNode) HomeDir() string {
-	return filepath.Join("/tmp", tn.Chain.Config().Name)
+	return path.Join("/var/cosmos-chain", tn.Chain.Config().Name)
 }
 
 // SetValidatorConfigAndPeers modifies the config for a validator node to start a chain
@@ -224,7 +212,7 @@ func (tn *ChainNode) SetValidatorConfigAndPeers(ctx context.Context, peers strin
 	}
 
 	fw := dockerutil.NewFileWriter(tn.logger(), tn.DockerClient, tn.TestName)
-	if err := fw.WriteFile(ctx, tn.Dir(), "config/config.toml", content); err != nil {
+	if err := fw.WriteFile(ctx, tn.VolumeName, "config/config.toml", content); err != nil {
 		return fmt.Errorf("overwriting config.toml: %w", err)
 	}
 
@@ -516,7 +504,7 @@ func (tn *ChainNode) InstantiateContract(ctx context.Context, keyName string, am
 
 	_, file := filepath.Split(fileName)
 	fw := dockerutil.NewFileWriter(tn.logger(), tn.DockerClient, tn.TestName)
-	if err := fw.WriteFile(ctx, tn.Dir(), file, content); err != nil {
+	if err := fw.WriteFile(ctx, tn.VolumeName, file, content); err != nil {
 		return "", fmt.Errorf("writing contract file to docker volume: %w", err)
 	}
 
@@ -811,7 +799,7 @@ func (tn *ChainNode) NodeID(ctx context.Context) (string, error) {
 	// we only have to tmjson.Unmarshal the raw content.
 
 	fr := dockerutil.NewFileRetriever(tn.logger(), tn.DockerClient, tn.TestName)
-	j, err := fr.SingleFileContent(ctx, tn.Dir(), "config/node_key.json")
+	j, err := fr.SingleFileContent(ctx, tn.VolumeName, "config/node_key.json")
 	if err != nil {
 		return "", fmt.Errorf("getting node_key.json content: %w", err)
 	}

--- a/internal/dockerutil/image.go
+++ b/internal/dockerutil/image.go
@@ -83,7 +83,7 @@ type ContainerOptions struct {
 	// Environment variables
 	Env []string
 
-	// If blank, defaults to a reasonable non-root user.
+	// If blank, defaults to the container's default user.
 	User string
 }
 
@@ -137,11 +137,6 @@ func (image *Image) createContainer(ctx context.Context, containerName, hostName
 		}); err != nil {
 			return "", fmt.Errorf("unable to remove container %s: %w", containerName, err)
 		}
-	}
-
-	// Ensure reasonable defaults.
-	if opts.User == "" {
-		opts.User = GetDockerUserString()
 	}
 
 	cc, err := image.client.ContainerCreate(

--- a/internal/dockerutil/setup.go
+++ b/internal/dockerutil/setup.go
@@ -33,6 +33,18 @@ type DockerSetupTestingT interface {
 // is unable to clean old resources from docker engine.
 const CleanupLabel = "ibc-test"
 
+// CleanupLabel is the "old" format.
+// Note that any new labels should follow the reverse DNS format suggested at
+// https://docs.docker.com/config/labels-custom-metadata/#key-format-recommendations.
+
+const (
+	// LabelPrefix is the reverse DNS format "namespace" for ibctest Docker labels.
+	LabelPrefix = "ventures.strangelove.ibctest."
+
+	// NodeOwnerLabel indicates the logical node owning a particular object (probably a volume).
+	NodeOwnerLabel = LabelPrefix + "node-owner"
+)
+
 // KeepVolumesOnFailure determines whether volumes associated with a test
 // using DockerSetup are retained or deleted following a test failure.
 //

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -104,7 +104,7 @@ func NewDockerRelayer(ctx context.Context, log *zap.Logger, testName string, cli
 		ImageRef:   containerImage.Ref(),
 		TestName:   testName,
 	}); err != nil {
-		return nil, fmt.Errorf("chown node home: %w", err)
+		return nil, fmt.Errorf("set volume owner: %w", err)
 	}
 
 	if init := r.c.Init(r.NodeHome()); len(init) > 0 {


### PR DESCRIPTION
A major milestone towards completing #200.

The remaining work will be to respect IBCTEST_SKIP_FAILURE_CLEANUP for
volumes, and adjusting the penumbra and internal/tendermint packages to
also use Docker volumes.