### PR TITLE
Extract mocktesting package

### DIFF
--- a/internal/mocktesting/doc.go
+++ b/internal/mocktesting/doc.go
@@ -1,0 +1,3 @@
+// Package mocktesting contains a mock instance of *testing.T
+// which is useful for testing ibctest's interactions with Go tests.
+package mocktesting

--- a/internal/mocktesting/t.go
+++ b/internal/mocktesting/t.go
@@ -1,0 +1,147 @@
+package mocktesting
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+// T satisfies a subset of testing.TB useful for tests around how ibctest interacts with instances of testing.T.
+//
+// The methods that are unique to T are RunCleanups and Simulate
+type T struct {
+	name string
+
+	HelperCalled bool
+
+	failCalled bool
+
+	cleanups    []func()
+	ranCleanups bool
+
+	Logs   []string
+	Errors []string
+	Skips  []string
+
+	// ParallelDelay sets how long to sleep on a call to t.Parallel,
+	// for tests that need to simulate t.Parallel blocking.
+	ParallelDelay time.Duration
+
+	// runner is set when using the RunTest function.
+	// Methods on T that require control flow will panic if runner is nil.
+	// runner *runner
+	simulating bool
+}
+
+// NewT returns a new T with the given name.
+func NewT(name string) *T {
+	if name == "" {
+		panic(fmt.Errorf("NewT: name must not be empty"))
+	}
+	return &T{name: name}
+}
+
+// Helper sets the t.HelperCalled field to true.
+func (t *T) Helper() {
+	t.HelperCalled = true
+}
+
+// Name returns the name provided to NewT.
+func (t *T) Name() string {
+	return t.name
+}
+
+// Failed reports whether t.Errorf was ever called.
+func (t *T) Failed() bool {
+	return t.failCalled || len(t.Errors) > 0
+}
+
+// Skipped reports whether t.Skip was ever called.
+func (t *T) Skipped() bool {
+	return len(t.Skips) > 0
+}
+
+// Cleanup adds f to the list of cleanup functions to invoke.
+// To actually invoke the functions, use t.RunCleanups.
+func (t *T) Cleanup(f func()) {
+	t.cleanups = append(t.cleanups, f)
+}
+
+// RunCleanups runs all the functions passed to t.Cleanup,
+// in reverse order just like the real testing.T.
+func (t *T) RunCleanups() {
+	if t.ranCleanups {
+		panic(fmt.Errorf("(*mocktesting.T).RunCleanups may only be called once per instance"))
+	}
+
+	// Cleanups are run in reverse order of insertion.
+	for i := len(t.cleanups) - 1; i >= 0; i-- {
+		t.cleanups[i]()
+	}
+	t.cleanups = nil // Can't use the slice again, so make it eligible for GC anyway.
+	t.ranCleanups = true
+}
+
+// Logf appends the formatted message to t.Logs.
+func (t *T) Logf(format string, args ...any) {
+	t.Logs = append(t.Logs, fmt.Sprintf(format, args...))
+}
+
+// Errorf appends the formatted error message to t.Errors.
+func (t *T) Errorf(format string, args ...any) {
+	t.Errors = append(t.Errors, fmt.Sprintf(format, args...))
+}
+
+// Skip appends fmt.Sprint(args...) to t.Skips.
+// Skip panics if called outside the context of RunTest.
+func (t *T) Skip(args ...any) {
+	if !t.simulating {
+		panic(fmt.Errorf("(*mocktesting.T).Skip may only be called from inside (*mocktesting.T).Simulate"))
+	}
+
+	t.Skips = append(t.Skips, fmt.Sprint(args...))
+	runtime.Goexit()
+}
+
+// Fail marks t as failed, without any control flow interaction.
+func (t *T) Fail() {
+	t.failCalled = true
+}
+
+// FailNow marks T as failed and stops execution.
+// FailNow panics if called outside the context of RunTest.
+func (t *T) FailNow() {
+	if !t.simulating {
+		panic(fmt.Errorf("(*mocktesting.T).FailNow may only be called from inside (*mocktesting.T).Simulate"))
+	}
+
+	t.failCalled = true
+	runtime.Goexit()
+}
+
+// Parallel blocks for the configured t.ParallelDelay and then returns.
+func (t *T) Parallel() {
+	time.Sleep(t.ParallelDelay)
+}
+
+// Simulate executes the given function in its own goroutine,
+// which is necessary for exercising methods that affect control flow,
+// such as t.Skip or t.FailNow.
+//
+// Simulate also runs t.RunCleanups after fn's execution finishes.
+func (t *T) Simulate(fn func()) {
+	t.simulating = true
+	defer func() {
+		t.simulating = false
+	}()
+
+	ch := make(chan struct{})
+
+	go func() {
+		defer close(ch)
+		defer t.RunCleanups()
+		fn()
+	}()
+
+	<-ch
+}

--- a/internal/mocktesting/t_test.go
+++ b/internal/mocktesting/t_test.go
@@ -1,0 +1,173 @@
+package mocktesting_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/strangelove-ventures/ibctest/internal/mocktesting"
+	"github.com/stretchr/testify/require"
+)
+
+func TestT_Name(t *testing.T) {
+	mt := mocktesting.NewT("foo")
+	require.Equal(t, mt.Name(), "foo")
+
+	require.Panics(t, func() {
+		_ = mocktesting.NewT("")
+	}, "empty name should be rejected")
+}
+
+func TestT_RunCleanups(t *testing.T) {
+	t.Run("panics if called multiple times", func(t *testing.T) {
+		mt := mocktesting.NewT("x")
+		require.NotPanics(t, func() {
+			mt.RunCleanups()
+		}, "first call to RunCleanups must succeed")
+		require.Panics(t, func() {
+			mt.RunCleanups()
+		}, "subsequent call to RunCleanups must panic")
+	})
+
+	t.Run("executes cleanups in reverse order", func(t *testing.T) {
+		var nums []int
+
+		mt := mocktesting.NewT("x")
+		mt.Cleanup(func() {
+			nums = append(nums, 1)
+		})
+		mt.Cleanup(func() {
+			nums = append(nums, 2)
+		})
+
+		mt.RunCleanups()
+
+		require.Equal(t, []int{2, 1}, nums)
+	})
+}
+
+func TestT_Logf(t *testing.T) {
+	mt := mocktesting.NewT("x")
+
+	require.Empty(t, mt.Logs)
+
+	mt.Logf("1 + 2 = %d", 3)
+	mt.Logf("4 + 5 = %d", 9)
+	require.Equal(t, []string{"1 + 2 = 3", "4 + 5 = 9"}, mt.Logs)
+
+	// Logging should not cause a failure, of course.
+	require.False(t, mt.Failed())
+}
+
+func TestT_Errorf(t *testing.T) {
+	mt := mocktesting.NewT("x")
+
+	require.Empty(t, mt.Errors)
+	require.False(t, mt.Failed())
+
+	mt.Errorf("non-zero exit: %d", 1)
+	require.Equal(t, []string{"non-zero exit: 1"}, mt.Errors)
+	require.True(t, mt.Failed())
+
+	// Valid to have more than one Errorf call.
+	mt.Errorf("non-zero exit: %d", 3)
+	require.Equal(t, []string{"non-zero exit: 1", "non-zero exit: 3"}, mt.Errors)
+	require.True(t, mt.Failed())
+}
+
+func TestT_Skip(t *testing.T) {
+	t.Run("panics outside of Simulate", func(t *testing.T) {
+		mt := mocktesting.NewT("x")
+		require.Panics(t, func() {
+			mt.Skip()
+		})
+	})
+
+	t.Run("stops control flow inside Simulate", func(t *testing.T) {
+		continuedAfterSkip := false
+		mt := mocktesting.NewT("x")
+
+		mt.Simulate(func() {
+			mt.Skip()
+			continuedAfterSkip = true
+		})
+
+		require.False(t, continuedAfterSkip, "control flow continued after t.Skip")
+	})
+
+	t.Run("appends to skip messages", func(t *testing.T) {
+		mt := mocktesting.NewT("x")
+
+		mt.Simulate(func() {
+			mt.Skip("foo")
+		})
+
+		require.Equal(t, []string{"foo"}, mt.Skips)
+		require.True(t, mt.Skipped())
+	})
+}
+
+func TestT_Fail(t *testing.T) {
+	mt := mocktesting.NewT("x")
+
+	require.False(t, mt.Failed())
+	mt.Fail()
+	require.True(t, mt.Failed())
+}
+
+func TestT_FailNow(t *testing.T) {
+	t.Run("panics outside of Simulate", func(t *testing.T) {
+		mt := mocktesting.NewT("x")
+		require.Panics(t, func() {
+			mt.FailNow()
+		})
+	})
+
+	t.Run("stops control flow inside Simulate", func(t *testing.T) {
+		continuedAfterFailNow := false
+		mt := mocktesting.NewT("x")
+
+		mt.Simulate(func() {
+			mt.FailNow()
+			continuedAfterFailNow = true
+		})
+
+		require.False(t, continuedAfterFailNow, "control flow continued after t.FailNow")
+		require.True(t, mt.Failed())
+	})
+
+	t.Run("does not append error messages", func(t *testing.T) {
+		mt := mocktesting.NewT("x")
+
+		mt.Simulate(func() {
+			mt.FailNow()
+		})
+
+		require.Empty(t, mt.Errors)
+	})
+}
+
+func TestT_Parallel(t *testing.T) {
+	const delay = 10 * time.Millisecond
+
+	mt := mocktesting.NewT("x")
+	before := time.Now()
+	mt.Parallel()
+	after := time.Now()
+
+	require.GreaterOrEqual(t, before.Add(delay).UnixNano(), after.UnixNano(), "mt.Parallel did not delay the minimum of 10ms")
+}
+
+func TestT_Simulate(t *testing.T) {
+	t.Run("runs cleanups", func(t *testing.T) {
+		cleanedUp := false
+
+		mt := mocktesting.NewT("x")
+		mt.Cleanup(func() {
+			cleanedUp = true
+		})
+
+		mt.Simulate(func() {})
+
+		require.True(t, cleanedUp)
+	})
+}

--- a/tempdir_test.go
+++ b/tempdir_test.go
@@ -1,60 +1,15 @@
 package ibctest_test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/internal/mocktesting"
 	"github.com/stretchr/testify/require"
 )
-
-type mockTempT struct {
-	name string
-
-	failed bool
-
-	helperCalled bool
-
-	cleanups []func()
-
-	logs   []string
-	errors []string
-}
-
-func (t *mockTempT) Helper() {
-	t.helperCalled = true
-}
-
-func (t *mockTempT) Name() string {
-	return t.name
-}
-
-func (t *mockTempT) Failed() bool {
-	return t.failed
-}
-
-func (t *mockTempT) Cleanup(f func()) {
-	t.cleanups = append(t.cleanups, f)
-}
-
-func (t *mockTempT) RunCleanups() {
-	// Cleanups are run in reverse order of insertion.
-	for i := len(t.cleanups) - 1; i >= 0; i-- {
-		t.cleanups[i]()
-	}
-	t.cleanups = nil
-}
-
-func (t *mockTempT) Logf(format string, args ...any) {
-	t.logs = append(t.logs, fmt.Sprintf(format, args...))
-}
-
-func (t *mockTempT) Errorf(format string, args ...any) {
-	t.errors = append(t.errors, fmt.Sprintf(format, args...))
-}
 
 func TestTempDir_Cleanup(t *testing.T) {
 	origKeep := ibctest.KeepTempDirOnFailure
@@ -66,7 +21,7 @@ func TestTempDir_Cleanup(t *testing.T) {
 		ibctest.KeepTempDirOnFailure = true
 
 		t.Run("test passed", func(t *testing.T) {
-			mt := &mockTempT{name: "t"}
+			mt := mocktesting.NewT("t")
 
 			dir := ibctest.TempDir(mt)
 			require.DirExists(t, dir)
@@ -74,17 +29,17 @@ func TestTempDir_Cleanup(t *testing.T) {
 			mt.RunCleanups()
 
 			require.NoDirExists(t, dir)
-			require.Empty(t, mt.logs)
+			require.Empty(t, mt.Logs)
 		})
 
 		t.Run("test failed", func(t *testing.T) {
-			mt := &mockTempT{name: "t"}
+			mt := mocktesting.NewT("t")
 
 			dir := ibctest.TempDir(mt)
 			require.DirExists(t, dir)
 			defer func() { _ = os.RemoveAll(dir) }()
 
-			mt.failed = true
+			mt.Fail()
 
 			mt.RunCleanups()
 
@@ -92,8 +47,8 @@ func TestTempDir_Cleanup(t *testing.T) {
 			require.DirExists(t, dir)
 
 			// And the last log message mentions the directory.
-			require.NotEmpty(t, mt.logs)
-			require.Contains(t, mt.logs[len(mt.logs)-1], dir)
+			require.NotEmpty(t, mt.Logs)
+			require.Contains(t, mt.Logs[len(mt.Logs)-1], dir)
 		})
 	})
 
@@ -106,17 +61,19 @@ func TestTempDir_Cleanup(t *testing.T) {
 		} {
 			failed := failed
 			t.Run(name, func(t *testing.T) {
-				mt := &mockTempT{name: "t"}
+				mt := mocktesting.NewT("t")
 
 				dir := ibctest.TempDir(mt)
 				require.DirExists(t, dir)
 
-				mt.failed = failed
+				if failed {
+					mt.Fail()
+				}
 
 				mt.RunCleanups()
 
 				require.NoDirExists(t, dir)
-				require.Empty(t, mt.logs)
+				require.Empty(t, mt.Logs)
 			})
 		}
 	})


### PR DESCRIPTION
To add tests around an upcoming feature (opt-in retention of Docker
volumes on test failure), I was going to need a third instance of a mock
*testing.T.

This extracts a more full-featured mock instance of *testing.T to be
used in existing and future tests that need to assert against
interactions with real tests.