### PR TITLE
Use IBCTEST_SKIP_FAILURE_CLEANUP to retain Docker volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Test authors must use
 [`ibctest.TempDir`](https://pkg.go.dev/github.com/strangelove-ventures/ibctest#TempDir)
 instead of `(*testing.T).Cleanup` to opt in to this behavior.
 
+By default, Docker volumes associated with tests are cleaned up at the end of each test run.
+That same `IBCTEST_SKIP_FAILURE_CLEANUP` controls whether the volumes associated with failed tests are pruned.
+
 ## Contributing
 
 Running `make ibctest` will produce an `ibctest` binary into `./bin`.

--- a/internal/dockerutil/setup.go
+++ b/internal/dockerutil/setup.go
@@ -3,7 +3,7 @@ package dockerutil
 import (
 	"context"
 	"fmt"
-	"testing"
+	"os"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -14,6 +14,18 @@ import (
 	"github.com/docker/docker/errdefs"
 )
 
+// DockerSetupTestingT is a subset of testing.T required for DockerSetup.
+type DockerSetupTestingT interface {
+	Helper()
+
+	Name() string
+
+	Failed() bool
+	Cleanup(func())
+
+	Logf(format string, args ...any)
+}
+
 // CleanupLabel is a docker label key targeted by DockerSetup when it cleans up docker resources.
 //
 // "ibctest" is perhaps a better name. However, for backwards compatability we preserve the original name of "ibc-test"
@@ -21,15 +33,25 @@ import (
 // is unable to clean old resources from docker engine.
 const CleanupLabel = "ibc-test"
 
+// KeepVolumesOnFailure determines whether volumes associated with a test
+// using DockerSetup are retained or deleted following a test failure.
+//
+// The value is false by default, but can be initialized to true by setting the
+// environment variable IBCTEST_SKIP_FAILURE_CLEANUP to a non-empty value.
+// Alternatively, importers of the dockerutil package may set the variable to true.
+// Because dockerutil is an internal package, the public API for setting this value
+// is ibctest.KeepDockerVolumesOnFailure(bool).
+var KeepVolumesOnFailure = os.Getenv("IBCTEST_SKIP_FAILURE_CLEANUP") != ""
+
 // DockerSetup returns a new Docker Client and the ID of a configured network, associated with t.
 //
-// If any part of the setup fails, t.Fatal is called.
-func DockerSetup(t *testing.T) (*client.Client, string) {
+// If any part of the setup fails, DockerSetup panics because the test cannot continue.
+func DockerSetup(t DockerSetupTestingT) (*client.Client, string) {
 	t.Helper()
 
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
-		t.Fatalf("failed to create docker client: %v", err)
+		panic(fmt.Errorf("failed to create docker client: %v", err))
 	}
 
 	// Clean up docker resources at end of test.
@@ -46,14 +68,14 @@ func DockerSetup(t *testing.T) (*client.Client, string) {
 		Labels: map[string]string{CleanupLabel: t.Name()},
 	})
 	if err != nil {
-		t.Fatalf("failed to create docker network: %v", err)
+		panic(fmt.Errorf("failed to create docker network: %v", err))
 	}
 
 	return cli, network.ID
 }
 
 // dockerCleanup will clean up Docker containers, networks, and the other various config files generated in testing
-func dockerCleanup(t *testing.T, cli *client.Client) func() {
+func dockerCleanup(t DockerSetupTestingT, cli *client.Client) func() {
 	return func() {
 		ctx := context.TODO()
 
@@ -91,18 +113,36 @@ func dockerCleanup(t *testing.T, cli *client.Client) func() {
 			cancel()
 
 			if err := cli.ContainerRemove(ctx, c.ID, types.ContainerRemoveOptions{
-				RemoveVolumes: true,
-				Force:         true,
+				// Not removing volumes with the container, because we separately handle them conditionally.
+				Force: true,
 			}); err != nil {
 				t.Logf("Failed to remove container %s during docker cleanup: %v", c.ID, err)
 			}
 		}
 
+		pruneVolumes(ctx, t, cli)
+
 		pruneNetworksWithRetry(ctx, t, cli)
 	}
 }
 
-func pruneNetworksWithRetry(ctx context.Context, t *testing.T, cli *client.Client) {
+func pruneVolumes(ctx context.Context, t DockerSetupTestingT, cli *client.Client) {
+	if KeepVolumesOnFailure && t.Failed() {
+		return
+	}
+
+	res, err := cli.VolumesPrune(ctx, filters.NewArgs(filters.Arg("label", CleanupLabel+"="+t.Name())))
+	if err != nil {
+		t.Logf("Failed to prune volumes during docker cleanup: %v", err)
+		return
+	}
+
+	if len(res.VolumesDeleted) > 0 {
+		t.Logf("Pruned %d volumes, reclaiming approximately %.1f MB", len(res.VolumesDeleted), float64(res.SpaceReclaimed)/(1024*1024))
+	}
+}
+
+func pruneNetworksWithRetry(ctx context.Context, t DockerSetupTestingT, cli *client.Client) {
 	var deleted []string
 	err := retry.Do(
 		func() error {

--- a/internal/dockerutil/setup_test.go
+++ b/internal/dockerutil/setup_test.go
@@ -1,0 +1,80 @@
+package dockerutil_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/errdefs"
+	"github.com/strangelove-ventures/ibctest/internal/dockerutil"
+	"github.com/strangelove-ventures/ibctest/internal/mocktesting"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerSetup_KeepVolumes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping due to short mode")
+	}
+
+	cli, _ := dockerutil.DockerSetup(t)
+
+	origKeep := dockerutil.KeepVolumesOnFailure
+	defer func() {
+		dockerutil.KeepVolumesOnFailure = origKeep
+	}()
+
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		keep       bool
+		passed     bool
+		volumeKept bool
+	}{
+		{keep: false, passed: false, volumeKept: false},
+		{keep: true, passed: false, volumeKept: true},
+		{keep: false, passed: true, volumeKept: false},
+		{keep: true, passed: true, volumeKept: false},
+	} {
+		tc := tc
+		state := "failed"
+		if tc.passed {
+			state = "passed"
+		}
+
+		testName := fmt.Sprintf("keep=%t, test %s", tc.keep, state)
+		t.Run(testName, func(t *testing.T) {
+			dockerutil.KeepVolumesOnFailure = tc.keep
+			mt := mocktesting.NewT(t.Name())
+
+			var volumeName string
+			mt.Simulate(func() {
+				cli, _ := dockerutil.DockerSetup(mt)
+
+				v, err := cli.VolumeCreate(ctx, volumetypes.VolumeCreateBody{
+					Labels: map[string]string{dockerutil.CleanupLabel: mt.Name()},
+				})
+				require.NoError(t, err)
+
+				volumeName = v.Name
+
+				if !tc.passed {
+					mt.Fail()
+				}
+			})
+
+			require.Equal(t, !tc.passed, mt.Failed())
+
+			_, err := cli.VolumeInspect(ctx, volumeName)
+			if !tc.volumeKept {
+				require.Truef(t, errdefs.IsNotFound(err), "expected not found error, got %v", err)
+				return
+			}
+
+			require.NoError(t, err)
+			if err := cli.VolumeRemove(ctx, volumeName, true); err != nil {
+				t.Logf("failed to remove volume %s: %v", volumeName, err)
+			}
+		})
+	}
+}

--- a/tempdir_test.go
+++ b/tempdir_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 func TestTempDir_Cleanup(t *testing.T) {
-	origKeep := ibctest.KeepTempDirOnFailure
+	origKeep := ibctest.KeepingTempDirOnFailure()
 	defer func() {
-		ibctest.KeepTempDirOnFailure = origKeep
+		ibctest.KeepTempDirOnFailure(origKeep)
 	}()
 
 	t.Run("keep=true", func(t *testing.T) {
-		ibctest.KeepTempDirOnFailure = true
+		ibctest.KeepTempDirOnFailure(true)
 
 		t.Run("test passed", func(t *testing.T) {
 			mt := mocktesting.NewT("t")
@@ -53,7 +53,7 @@ func TestTempDir_Cleanup(t *testing.T) {
 	})
 
 	t.Run("keep=false", func(t *testing.T) {
-		ibctest.KeepTempDirOnFailure = false
+		ibctest.KeepTempDirOnFailure(false)
 
 		for name, failed := range map[string]bool{
 			"test passed": false,

--- a/test_setup.go
+++ b/test_setup.go
@@ -20,6 +20,16 @@ const (
 	FaucetAccountKeyName = "faucet"
 )
 
+// KeepDockerVolumesOnFailure sets whether volumes associated with a particular test
+// are retained or deleted following a test failure.
+//
+// The value is false by default, but can be initialized to true by setting the
+// environment variable IBCTEST_SKIP_FAILURE_CLEANUP to a non-empty value.
+// Alternatively, importers of the ibctest package may call KeepDockerVolumesOnFailure(true).
+func KeepDockerVolumesOnFailure(b bool) {
+	dockerutil.KeepVolumesOnFailure = b
+}
+
 // DockerSetup returns a new Docker Client and the ID of a configured network, associated with t.
 //
 // If any part of the setup fails, t.Fatal is called.


### PR DESCRIPTION
(Draft until #212 is merged.)

Only if that environment variable is non-empty and the test fails.

As of this commit, this only skips calling docker volume prune on the
volumes. The next step in this sequence will be to add an option to copy
the volumes' content to local disk.
