### PR TITLE
Begin changing chain/internal/tendermint to use Docker volumes

### DIFF
--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -132,8 +132,14 @@ func (p *PenumbraAppNode) AllocationsInputFileContainer() string {
 	return filepath.Join(p.HomeDir(), "allocations.csv")
 }
 
-func (p *PenumbraAppNode) GenesisFile() string {
-	return filepath.Join(p.Dir(), "node0", "tendermint", "config", "genesis.json")
+func (p *PenumbraAppNode) genesisFileContent(ctx context.Context) ([]byte, error) {
+	fr := dockerutil.NewFileRetriever(p.log, p.DockerClient, p.TestName)
+	gen, err := fr.SingleFileContent(ctx, p.Dir(), "node0/tendermint/config/genesis.json")
+	if err != nil {
+		return nil, fmt.Errorf("getting genesis.json content: %w", err)
+	}
+
+	return gen, nil
 }
 
 func (p *PenumbraAppNode) ValidatorPrivateKeyFile(nodeNum int) string {


### PR DESCRIPTION
Still using the host mounts rather than independent Docker volumes at
this point, but changing internal file copying to use the
volume-compatible APIs for a simpler switchover later.

For #200.