### PR TITLE
Default to Docker containers' default users

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -713,7 +713,6 @@ func (tn *ChainNode) CreateNodeContainer(ctx context.Context) error {
 			Cmd:        cmd,
 
 			Hostname: tn.HostName(),
-			User:     dockerutil.GetDockerUserString(),
 
 			Labels: map[string]string{dockerutil.CleanupLabel: tn.TestName},
 

--- a/internal/dockerutil/image.go
+++ b/internal/dockerutil/image.go
@@ -83,7 +83,7 @@ type ContainerOptions struct {
 	// Environment variables
 	Env []string
 
-	// If blank, defaults to a reasonable non-root user.
+	// If blank, defaults to the container's default user.
 	User string
 }
 
@@ -137,11 +137,6 @@ func (image *Image) createContainer(ctx context.Context, containerName, hostName
 		}); err != nil {
 			return "", fmt.Errorf("unable to remove container %s: %w", containerName, err)
 		}
-	}
-
-	// Ensure reasonable defaults.
-	if opts.User == "" {
-		opts.User = GetDockerUserString()
 	}
 
 	cc, err := image.client.ContainerCreate(


### PR DESCRIPTION
Setting a different user by default creates strange permission issues
that manifest differently on macOS and Linux.
