### PR TITLE
Migrate remaining direct file writes to docker operations

### DIFF
--- a/chain/internal/tendermint/tendermint_node.go
+++ b/chain/internal/tendermint/tendermint_node.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -137,25 +138,18 @@ func (tn *TendermintNode) PrivValKeyFilePath() string {
 	return filepath.Join(tn.Dir(), "config", "priv_validator_key.json")
 }
 
-func (tn *TendermintNode) TMConfigPath() string {
-	return filepath.Join(tn.Dir(), "config", "config.toml")
-}
-
-func (tn *TendermintNode) TMConfigPathContainer() string {
-	return filepath.Join(tn.HomeDir(), "config", "config.toml")
-}
-
 // Bind returns the home folder bind point for running the node
 func (tn *TendermintNode) Bind() []string {
 	return []string{fmt.Sprintf("%s:%s", tn.Dir(), tn.HomeDir())}
 }
 
 func (tn *TendermintNode) HomeDir() string {
-	return filepath.Join("/tmp", tn.Chain.Config().Name)
+	return path.Join("/tmp", tn.Chain.Config().Name)
 }
 
 func (tn *TendermintNode) sedCommandForConfigFile(key, newValue string) string {
-	return fmt.Sprintf("sed -i \"/^%s = .*/ s//%s = %s/\" %s", key, key, newValue, tn.TMConfigPathContainer())
+	configPath := path.Join(tn.HomeDir(), "config/config.toml")
+	return fmt.Sprintf("sed -i \"/^%s = .*/ s//%s = %s/\" %s", key, key, newValue, configPath)
 }
 
 // SetConfigAndPeers modifies the config for a validator node to start a chain

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -168,14 +168,15 @@ func (p *PenumbraAppNode) GenerateGenesisFile(
 	if err != nil {
 		return fmt.Errorf("error marshalling validators to json: %w", err)
 	}
-	if err := os.WriteFile(p.ValidatorsInputFile(), validatorsJson, 0644); err != nil {
+	fw := dockerutil.NewFileWriter(p.log, p.DockerClient, p.TestName)
+	if err := fw.WriteFile(ctx, p.Dir(), "validators.json", validatorsJson); err != nil {
 		return fmt.Errorf("error writing validators to file: %w", err)
 	}
 	allocationsCsv := []byte(`"amount","denom","address"\n`)
 	for _, allocation := range allocations {
 		allocationsCsv = append(allocationsCsv, []byte(fmt.Sprintf(`"%d","%s","%s"\n`, allocation.Amount, allocation.Denom, allocation.Address))...)
 	}
-	if err := os.WriteFile(p.AllocationsInputFile(), allocationsCsv, 0644); err != nil {
+	if err := fw.WriteFile(ctx, p.Dir(), "allocations.csv", allocationsCsv); err != nil {
 		return fmt.Errorf("error writing allocations to file: %w", err)
 	}
 	cmd := []string{


### PR DESCRIPTION
I think this is all the outstanding os.WriteFile and os.ReadFile calls.
This should enable switching the host mounts to docker volumes in an
upcoming commit.

For #200.