### PR TITLE
Migrate to Docker volumes

### DIFF
--- a/chain/cosmos/broadcaster.go
+++ b/chain/cosmos/broadcaster.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -97,7 +97,7 @@ func (b *Broadcaster) GetClientContext(ctx context.Context, user broadcast.User)
 	_, ok := b.keyrings[user]
 	if !ok {
 		localDir := b.t.TempDir()
-		containerKeyringDir := filepath.Join(cn.HomeDir(), "keyring-test")
+		containerKeyringDir := path.Join(cn.HomeDir(), "keyring-test")
 		kr, err := dockerutil.NewLocalKeyringFromDockerContainer(ctx, cn.DockerClient, localDir, containerKeyringDir, cn.containerID)
 		if err != nil {
 			return client.Context{}, err
@@ -150,9 +150,10 @@ func (b *Broadcaster) defaultClientContext(fromUser broadcast.User, sdkAdd sdk.A
 		WithAccountRetriever(authtypes.AccountRetriever{}).
 		WithKeyring(kr).
 		WithBroadcastMode(flags.BroadcastBlock).
-		WithCodec(defaultEncoding.Marshaler).
-		WithHomeDir(cn.Home)
+		WithCodec(defaultEncoding.Marshaler)
 
+	// NOTE: the returned context used to have .WithHomeDir(cn.Home),
+	// but that field no longer exists and the test against Broadcaster still passes without it.
 }
 
 // defaultTxFactory creates a new Factory with default configuration.

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -14,10 +14,12 @@ import (
 	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	chanTypes "github.com/cosmos/ibc-go/v4/modules/core/04-channel/types"
 	dockertypes "github.com/docker/docker/api/types"
+	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
 	"github.com/strangelove-ventures/ibctest/chain/internal/tendermint"
 	"github.com/strangelove-ventures/ibctest/ibc"
 	"github.com/strangelove-ventures/ibctest/internal/blockdb"
+	"github.com/strangelove-ventures/ibctest/internal/dockerutil"
 	"github.com/strangelove-ventures/ibctest/test"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -77,9 +79,11 @@ func (c *CosmosChain) Config() ibc.ChainConfig {
 }
 
 // Implements Chain interface
-func (c *CosmosChain) Initialize(testName string, homeDirectory string, cli *client.Client, networkID string) error {
-	c.initializeChainNodes(testName, homeDirectory, cli, networkID)
-	return nil
+func (c *CosmosChain) Initialize(testName string, _ string, cli *client.Client, networkID string) error {
+	// The Initialize interface needs to change to accept a context,
+	// but there are other implementations that still need to switch
+	// to Docker volumes first.
+	return c.initializeChainNodes(context.TODO(), testName, cli, networkID)
 }
 
 func (c *CosmosChain) getFullNode() *ChainNode {
@@ -262,16 +266,16 @@ func (c *CosmosChain) GetGasFeesInNativeDenom(gasPaid int64) int64 {
 
 // creates the test node objects required for bootstrapping tests
 func (c *CosmosChain) initializeChainNodes(
-	testName, home string,
+	ctx context.Context,
+	testName string,
 	cli *client.Client,
 	networkID string,
-) {
-	var chainNodes []*ChainNode
+) error {
 	count := c.numValidators + c.numFullNodes
 	chainCfg := c.Config()
 	for _, image := range chainCfg.Images {
 		rc, err := cli.ImagePull(
-			context.TODO(),
+			ctx,
 			image.Repository+":"+image.Version,
 			dockertypes.ImagePullOptions{},
 		)
@@ -286,22 +290,60 @@ func (c *CosmosChain) initializeChainNodes(
 			_ = rc.Close()
 		}
 	}
-	for i := 0; i < count; i++ {
-		tn := &ChainNode{
-			log: c.log,
 
-			Home:         home,
-			Index:        i,
-			Chain:        c,
-			DockerClient: cli,
-			NetworkID:    networkID,
-			TestName:     testName,
-			Image:        chainCfg.Images[0],
-		}
-		tn.MkDir()
-		chainNodes = append(chainNodes, tn)
+	image := chainCfg.Images[0]
+	chainNodes := make([]*ChainNode, count)
+	eg, egCtx := errgroup.WithContext(ctx)
+	for i := 0; i < count; i++ {
+		i := i
+		eg.Go(func() error {
+			// Construct the ChainNode first so we can access its name.
+			// The ChainNode's VolumeName cannot be set until after we create the volume.
+			tn := &ChainNode{
+				log: c.log,
+
+				Index:        i,
+				Chain:        c,
+				DockerClient: cli,
+				NetworkID:    networkID,
+				TestName:     testName,
+				Image:        image,
+			}
+
+			v, err := cli.VolumeCreate(egCtx, volumetypes.VolumeCreateBody{
+				Labels: map[string]string{
+					dockerutil.CleanupLabel: testName,
+
+					dockerutil.NodeOwnerLabel: tn.Name(),
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("creating volume for chain node: %w", err)
+			}
+			tn.VolumeName = v.Name
+
+			if err := dockerutil.SetVolumeOwner(ctx, dockerutil.VolumeOwnerOptions{
+				Log: c.log,
+
+				Client: cli,
+
+				VolumeName: v.Name,
+				ImageRef:   image.Ref(),
+				TestName:   testName,
+			}); err != nil {
+				return fmt.Errorf("set volume owner: %w", err)
+			}
+
+			chainNodes[i] = tn
+
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return err
 	}
 	c.ChainNodes = chainNodes
+	return nil
 }
 
 type GenesisValidatorPubKey struct {

--- a/chain/internal/tendermint/tendermint_node.go
+++ b/chain/internal/tendermint/tendermint_node.go
@@ -6,9 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -19,6 +17,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/strangelove-ventures/ibctest/ibc"
 	"github.com/strangelove-ventures/ibctest/internal/dockerutil"
+	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/p2p"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
@@ -30,7 +29,7 @@ import (
 type TendermintNode struct {
 	Log *zap.Logger
 
-	Home         string
+	VolumeName   string
 	Index        int
 	Chain        ibc.Chain
 	NetworkID    string
@@ -92,21 +91,9 @@ func (tn *TendermintNode) HostName() string {
 	return dockerutil.CondenseHostName(tn.Name())
 }
 
-// Dir is the directory where the test node files are stored
-func (tn *TendermintNode) Dir() string {
-	return filepath.Join(tn.Home, tn.Name())
-}
-
-// MkDir creates the directory for the testnode
-func (tn *TendermintNode) MkDir() {
-	if err := os.MkdirAll(tn.Dir(), 0755); err != nil {
-		panic(err)
-	}
-}
-
 func (tn *TendermintNode) GenesisFileContent(ctx context.Context) ([]byte, error) {
 	fr := dockerutil.NewFileRetriever(tn.logger(), tn.DockerClient, tn.TestName)
-	gen, err := fr.SingleFileContent(ctx, tn.Dir(), "config/genesis.json")
+	gen, err := fr.SingleFileContent(ctx, tn.VolumeName, "config/genesis.json")
 	if err != nil {
 		return nil, fmt.Errorf("getting genesis.json content: %w", err)
 	}
@@ -116,7 +103,7 @@ func (tn *TendermintNode) GenesisFileContent(ctx context.Context) ([]byte, error
 
 func (tn *TendermintNode) OverwriteGenesisFile(ctx context.Context, content []byte) error {
 	fw := dockerutil.NewFileWriter(tn.logger(), tn.DockerClient, tn.TestName)
-	if err := fw.WriteFile(ctx, tn.Dir(), "config/genesis.json", content); err != nil {
+	if err := fw.WriteFile(ctx, tn.VolumeName, "config/genesis.json", content); err != nil {
 		return fmt.Errorf("overwriting genesis.json: %w", err)
 	}
 
@@ -134,17 +121,13 @@ type PrivValidatorKeyFile struct {
 	PrivKey PrivValidatorKey `json:"priv_key"`
 }
 
-func (tn *TendermintNode) PrivValKeyFilePath() string {
-	return filepath.Join(tn.Dir(), "config", "priv_validator_key.json")
-}
-
 // Bind returns the home folder bind point for running the node
 func (tn *TendermintNode) Bind() []string {
-	return []string{fmt.Sprintf("%s:%s", tn.Dir(), tn.HomeDir())}
+	return []string{fmt.Sprintf("%s:%s", tn.VolumeName, tn.HomeDir())}
 }
 
 func (tn *TendermintNode) HomeDir() string {
-	return path.Join("/tmp", tn.Chain.Config().Name)
+	return path.Join("/var/tendermint", tn.Chain.Config().Name)
 }
 
 func (tn *TendermintNode) sedCommandForConfigFile(key, newValue string) string {
@@ -275,23 +258,33 @@ func (tn *TendermintNode) InitFullNodeFiles(ctx context.Context) error {
 }
 
 // NodeID returns the node of a given node
-func (tn *TendermintNode) NodeID() (string, error) {
-	nodeKey, err := p2p.LoadNodeKey(filepath.Join(tn.Dir(), "config", "node_key.json"))
+func (tn *TendermintNode) NodeID(ctx context.Context) (string, error) {
+	// This used to call p2p.LoadNodeKey against the file on the host,
+	// but because we are transitioning to operating on Docker volumes,
+	// we only have to tmjson.Unmarshal the raw content.
+	fr := dockerutil.NewFileRetriever(tn.logger(), tn.DockerClient, tn.TestName)
+	j, err := fr.SingleFileContent(ctx, tn.VolumeName, "config/node_key.json")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("getting node_key.json content: %w", err)
 	}
-	return string(nodeKey.ID()), nil
+
+	var nk p2p.NodeKey
+	if err := tmjson.Unmarshal(j, &nk); err != nil {
+		return "", fmt.Errorf("unmarshaling node_key.json: %w", err)
+	}
+
+	return string(nk.ID()), nil
 }
 
 // PeerString returns the string for connecting the nodes passed in
-func (tn TendermintNodes) PeerString(node *TendermintNode) string {
+func (tn TendermintNodes) PeerString(ctx context.Context, node *TendermintNode) string {
 	addrs := make([]string, len(tn))
 	for i, n := range tn {
 		if n == node {
 			// don't peer with ourself
 			continue
 		}
-		id, err := n.NodeID()
+		id, err := n.NodeID(ctx)
 		if err != nil {
 			// TODO: would this be better to panic?
 			// When would NodeId return an error?

--- a/chain/internal/tendermint/tendermint_node.go
+++ b/chain/internal/tendermint/tendermint_node.go
@@ -182,7 +182,6 @@ func (tn *TendermintNode) CreateNodeContainer(ctx context.Context, additionalFla
 			Cmd:        cmd,
 
 			Hostname: tn.HostName(),
-			User:     dockerutil.GetDockerUserString(),
 
 			Labels: map[string]string{dockerutil.CleanupLabel: tn.TestName},
 

--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -23,7 +22,7 @@ type PenumbraAppNode struct {
 	log *zap.Logger
 
 	Index        int
-	Home         string
+	VolumeName   string
 	Chain        ibc.Chain
 	TestName     string
 	NetworkID    string
@@ -58,21 +57,9 @@ func (p *PenumbraAppNode) HostName() string {
 	return dockerutil.CondenseHostName(p.Name())
 }
 
-// Dir is the directory where the test node files are stored
-func (p *PenumbraAppNode) Dir() string {
-	return fmt.Sprintf("%s/%s/", p.Home, p.Name())
-}
-
-// MkDir creates the directory for the testnode
-func (p *PenumbraAppNode) MkDir() {
-	if err := os.MkdirAll(p.Dir(), 0755); err != nil {
-		panic(err)
-	}
-}
-
 // Bind returns the home folder bind point for running the node
 func (p *PenumbraAppNode) Bind() []string {
-	return []string{fmt.Sprintf("%s:%s", p.Dir(), p.HomeDir())}
+	return []string{fmt.Sprintf("%s:%s", p.VolumeName, p.HomeDir())}
 }
 
 func (p *PenumbraAppNode) HomeDir() string {
@@ -104,10 +91,6 @@ func (p *PenumbraAppNode) InitValidatorFile(ctx context.Context) error {
 	return err
 }
 
-func (p *PenumbraAppNode) ValidatorDefinitionTemplateFilePath() string {
-	return filepath.Join(p.Dir(), "validator.json")
-}
-
 func (p *PenumbraAppNode) ValidatorDefinitionTemplateFilePathContainer() string {
 	return filepath.Join(p.HomeDir(), "validator.json")
 }
@@ -116,16 +99,8 @@ func (p *PenumbraAppNode) WalletPathContainer() string {
 	return filepath.Join(p.HomeDir(), "wallet")
 }
 
-func (p *PenumbraAppNode) ValidatorsInputFile() string {
-	return filepath.Join(p.Dir(), "validators.json")
-}
-
 func (p *PenumbraAppNode) ValidatorsInputFileContainer() string {
 	return filepath.Join(p.HomeDir(), "validators.json")
-}
-
-func (p *PenumbraAppNode) AllocationsInputFile() string {
-	return filepath.Join(p.Dir(), "allocations.csv")
 }
 
 func (p *PenumbraAppNode) AllocationsInputFileContainer() string {
@@ -134,16 +109,12 @@ func (p *PenumbraAppNode) AllocationsInputFileContainer() string {
 
 func (p *PenumbraAppNode) genesisFileContent(ctx context.Context) ([]byte, error) {
 	fr := dockerutil.NewFileRetriever(p.log, p.DockerClient, p.TestName)
-	gen, err := fr.SingleFileContent(ctx, p.Dir(), "node0/tendermint/config/genesis.json")
+	gen, err := fr.SingleFileContent(ctx, p.VolumeName, "node0/tendermint/config/genesis.json")
 	if err != nil {
 		return nil, fmt.Errorf("getting genesis.json content: %w", err)
 	}
 
 	return gen, nil
-}
-
-func (p *PenumbraAppNode) ValidatorPrivateKeyFile(nodeNum int) string {
-	return filepath.Join(p.Dir(), fmt.Sprintf("node%d", nodeNum), "tendermint", "config", "priv_validator_key.json")
 }
 
 func (p *PenumbraAppNode) Cleanup(ctx context.Context) error {
@@ -169,14 +140,14 @@ func (p *PenumbraAppNode) GenerateGenesisFile(
 		return fmt.Errorf("error marshalling validators to json: %w", err)
 	}
 	fw := dockerutil.NewFileWriter(p.log, p.DockerClient, p.TestName)
-	if err := fw.WriteFile(ctx, p.Dir(), "validators.json", validatorsJson); err != nil {
+	if err := fw.WriteFile(ctx, p.VolumeName, "validators.json", validatorsJson); err != nil {
 		return fmt.Errorf("error writing validators to file: %w", err)
 	}
 	allocationsCsv := []byte(`"amount","denom","address"\n`)
 	for _, allocation := range allocations {
 		allocationsCsv = append(allocationsCsv, []byte(fmt.Sprintf(`"%d","%s","%s"\n`, allocation.Amount, allocation.Denom, allocation.Address))...)
 	}
-	if err := fw.WriteFile(ctx, p.Dir(), "allocations.csv", allocationsCsv); err != nil {
+	if err := fw.WriteFile(ctx, p.VolumeName, "allocations.csv", allocationsCsv); err != nil {
 		return fmt.Errorf("error writing allocations to file: %w", err)
 	}
 	cmd := []string{

--- a/internal/dockerutil/image.go
+++ b/internal/dockerutil/image.go
@@ -83,7 +83,7 @@ type ContainerOptions struct {
 	// Environment variables
 	Env []string
 
-	// If blank, defaults to a reasonable non-root user.
+	// If blank, defaults to the container's default user.
 	User string
 }
 
@@ -137,11 +137,6 @@ func (image *Image) createContainer(ctx context.Context, containerName, hostName
 		}); err != nil {
 			return "", fmt.Errorf("unable to remove container %s: %w", containerName, err)
 		}
-	}
-
-	// Ensure reasonable defaults.
-	if opts.User == "" {
-		opts.User = GetDockerUserString()
 	}
 
 	cc, err := image.client.ContainerCreate(

--- a/internal/dockerutil/setup.go
+++ b/internal/dockerutil/setup.go
@@ -33,6 +33,18 @@ type DockerSetupTestingT interface {
 // is unable to clean old resources from docker engine.
 const CleanupLabel = "ibc-test"
 
+// CleanupLabel is the "old" format.
+// Note that any new labels should follow the reverse DNS format suggested at
+// https://docs.docker.com/config/labels-custom-metadata/#key-format-recommendations.
+
+const (
+	// LabelPrefix is the reverse DNS format "namespace" for ibctest Docker labels.
+	LabelPrefix = "ventures.strangelove.ibctest."
+
+	// NodeOwnerLabel indicates the logical node owning a particular object (probably a volume).
+	NodeOwnerLabel = LabelPrefix + "node-owner"
+)
+
 // KeepVolumesOnFailure determines whether volumes associated with a test
 // using DockerSetup are retained or deleted following a test failure.
 //

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -104,7 +104,7 @@ func NewDockerRelayer(ctx context.Context, log *zap.Logger, testName string, cli
 		ImageRef:   containerImage.Ref(),
 		TestName:   testName,
 	}); err != nil {
-		return nil, fmt.Errorf("chown node home: %w", err)
+		return nil, fmt.Errorf("set volume owner: %w", err)
 	}
 
 	if init := r.c.Init(r.NodeHome()); len(init) > 0 {


### PR DESCRIPTION
Complete the migration from host mounts to Docker volumes.

I wanted to split this into smaller steps, but it seemed that this last step needed to happen all at once.

Switch all the chains to using Docker volumes, default to the containers' default Docker user in most circumstances, and add an additional label to volumes to make post hoc debugging a little simpler.

Closes #200.