### PR TITLE
Remove home directory from chain initialization

### DIFF
--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -79,11 +79,11 @@ func (c *CosmosChain) Config() ibc.ChainConfig {
 }
 
 // Implements Chain interface
-func (c *CosmosChain) Initialize(testName string, _ string, cli *client.Client, networkID string) error {
+func (c *CosmosChain) Initialize(ctx context.Context, testName string, cli *client.Client, networkID string) error {
 	// The Initialize interface needs to change to accept a context,
 	// but there are other implementations that still need to switch
 	// to Docker volumes first.
-	return c.initializeChainNodes(context.TODO(), testName, cli, networkID)
+	return c.initializeChainNodes(ctx, testName, cli, networkID)
 }
 
 func (c *CosmosChain) getFullNode() *ChainNode {

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -102,8 +102,8 @@ func (c *PenumbraChain) Config() ibc.ChainConfig {
 }
 
 // Implements Chain interface
-func (c *PenumbraChain) Initialize(testName string, homeDirectory string, cli *client.Client, networkID string) error {
-	return c.initializeChainNodes(testName, homeDirectory, cli, networkID)
+func (c *PenumbraChain) Initialize(ctx context.Context, testName string, cli *client.Client, networkID string) error {
+	return c.initializeChainNodes(ctx, testName, cli, networkID)
 }
 
 // Exec implements chain interface.
@@ -217,11 +217,11 @@ func (c *PenumbraChain) GetGasFeesInNativeDenom(gasPaid int64) int64 {
 
 // creates the test node objects required for bootstrapping tests
 func (c *PenumbraChain) initializeChainNodes(
-	testName, home string,
+	ctx context.Context,
+	testName string,
 	cli *client.Client,
 	networkID string,
 ) error {
-	ctx := context.TODO()
 	penumbraNodes := []PenumbraNode{}
 	count := c.numValidators + c.numFullNodes
 	chainCfg := c.Config()

--- a/chain/penumbra/penumbra_chain_test.go
+++ b/chain/penumbra/penumbra_chain_test.go
@@ -19,7 +19,6 @@ func TestPenumbraChainStart(t *testing.T) {
 	t.Parallel()
 
 	client, network := ibctest.DockerSetup(t)
-	home := ibctest.TempDir(t) // Must be before chain cleanup to avoid test error during cleanup.
 
 	nv := 4
 
@@ -40,7 +39,7 @@ func TestPenumbraChainStart(t *testing.T) {
 
 	ctx := context.Background()
 
-	err = chain.Initialize(t.Name(), home, client, network)
+	err = chain.Initialize(ctx, t.Name(), client, network)
 	require.NoError(t, err, "failed to initialize penumbra chain")
 
 	err = chain.Start(t.Name(), ctx)

--- a/chainset.go
+++ b/chainset.go
@@ -49,13 +49,13 @@ func newChainSet(log *zap.Logger, chains []ibc.Chain) *chainSet {
 // Initialize concurrently calls Initialize against each chain in the set.
 // Each chain may run a docker pull command,
 // so with a cold image cache, running concurrently may save some time.
-func (cs *chainSet) Initialize(testName string, homeDir string, cli *client.Client, networkID string) error {
+func (cs *chainSet) Initialize(ctx context.Context, testName string,  cli *client.Client, networkID string) error {
 	var eg errgroup.Group
 
 	for c := range cs.chains {
 		c := c
 		eg.Go(func() error {
-			if err := c.Initialize(testName, homeDir, cli, networkID); err != nil {
+			if err := c.Initialize(ctx, testName, cli, networkID); err != nil {
 				return fmt.Errorf("failed to initialize chain %s: %w", c.Config().Name, err)
 			}
 

--- a/conformance/flush.go
+++ b/conformance/flush.go
@@ -21,7 +21,6 @@ func TestRelayerFlushing(t *testing.T, cf ibctest.ChainFactory, rf ibctest.Relay
 	// but check that capability first in case we can avoid setup.
 	requireCapabilities(t, rep, rf, relayer.FlushPackets)
 
-	home := ibctest.TempDir(t)
 	client, network := ibctest.DockerSetup(t)
 
 	req := require.New(rep.TestifyT(t))
@@ -54,7 +53,6 @@ func TestRelayerFlushing(t *testing.T, cf ibctest.ChainFactory, rf ibctest.Relay
 
 	req.NoError(ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
 		TestName:          t.Name(),
-		HomeDir:           home,
 		Client:            client,
 		NetworkID:         network,
 		CreateChannelOpts: ibc.DefaultChannelOpts(),

--- a/conformance/relayersetup.go
+++ b/conformance/relayersetup.go
@@ -18,7 +18,6 @@ import (
 func TestRelayerSetup(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory, rep *testreporter.Reporter) {
 	rep.TrackTest(t)
 
-	home := ibctest.TempDir(t)
 	client, network := ibctest.DockerSetup(t)
 
 	req := require.New(rep.TestifyT(t))
@@ -53,7 +52,6 @@ func TestRelayerSetup(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerF
 
 	req.NoError(ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
 		TestName:  t.Name(),
-		HomeDir:   home,
 		Client:    client,
 		NetworkID: network,
 

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -304,8 +304,7 @@ func TestChainPair(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFact
 	// funds relayer src and dst wallets on respective chain in genesis
 	// creates a faucet account on the both chains (separate fullnode)
 	// funds faucet accounts in genesis
-	home := ibctest.TempDir(t)
-	_, channels, err := ibctest.StartChainPairAndRelayer(t, ctx, rep, client, network, home, srcChain, dstChain, rf, preRelayerStartFuncs)
+	_, channels, err := ibctest.StartChainPairAndRelayer(t, ctx, rep, client, network, srcChain, dstChain, rf, preRelayerStartFuncs)
 	req.NoError(err, "failed to StartChainPairAndRelayer")
 
 	for _, testCase := range testCases {

--- a/examples/packet_forward_test.go
+++ b/examples/packet_forward_test.go
@@ -19,7 +19,6 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		t.Skip()
 	}
 
-	home := ibctest.TempDir(t)
 	client, network := ibctest.DockerSetup(t)
 
 	rep := testreporter.NewNopReporter()
@@ -65,7 +64,6 @@ func TestPacketForwardMiddleware(t *testing.T) {
 
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
 		TestName:  t.Name(),
-		HomeDir:   home,
 		Client:    client,
 		NetworkID: network,
 

--- a/ibc/chain.go
+++ b/ibc/chain.go
@@ -11,7 +11,7 @@ type Chain interface {
 	Config() ChainConfig
 
 	// initializes node structs so that things like initializing keys can be done before starting the chain
-	Initialize(testName string, homeDirectory string, cli *client.Client, networkID string) error
+	Initialize(ctx context.Context, testName string, cli *client.Client, networkID string) error
 
 	// sets up everything needed (validators, gentx, fullnodes, peering, additional accounts) for chain to start from genesis
 	Start(testName string, ctx context.Context, additionalGenesisWallets ...WalletAmount) error

--- a/interchain.go
+++ b/interchain.go
@@ -155,7 +155,6 @@ func (ic *Interchain) AddLink(link InterchainLink) *Interchain {
 // InterchainBuildOptions describes configuration for (*Interchain).Build.
 type InterchainBuildOptions struct {
 	TestName string
-	HomeDir  string
 
 	Client    *client.Client
 	NetworkID string
@@ -195,7 +194,7 @@ func (ic *Interchain) Build(ctx context.Context, rep *testreporter.RelayerExecRe
 	ic.cs = newChainSet(ic.log, chains)
 
 	// Initialize the chains (pull docker images, etc.).
-	if err := ic.cs.Initialize(opts.TestName, opts.HomeDir, opts.Client, opts.NetworkID); err != nil {
+	if err := ic.cs.Initialize(ctx, opts.TestName, opts.Client, opts.NetworkID); err != nil {
 		return fmt.Errorf("failed to initialize chains: %w", err)
 	}
 

--- a/interchain_test.go
+++ b/interchain_test.go
@@ -30,7 +30,6 @@ func TestInterchain_DuplicateChain(t *testing.T) {
 
 	t.Parallel()
 
-	home := ibctest.TempDir(t)
 	client, network := ibctest.DockerSetup(t)
 
 	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
@@ -64,7 +63,6 @@ func TestInterchain_DuplicateChain(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
 		TestName:  t.Name(),
-		HomeDir:   home,
 		Client:    client,
 		NetworkID: network,
 
@@ -80,7 +78,6 @@ func TestInterchain_GetRelayerWallets(t *testing.T) {
 
 	t.Parallel()
 
-	home := ibctest.TempDir(t)
 	client, network := ibctest.DockerSetup(t)
 
 	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
@@ -114,7 +111,6 @@ func TestInterchain_GetRelayerWallets(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
 		TestName:  t.Name(),
-		HomeDir:   home,
 		Client:    client,
 		NetworkID: network,
 
@@ -161,7 +157,6 @@ func TestInterchain_CreateUser(t *testing.T) {
 
 	t.Parallel()
 
-	home := ibctest.TempDir(t)
 	client, network := ibctest.DockerSetup(t)
 
 	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
@@ -183,7 +178,6 @@ func TestInterchain_CreateUser(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
 		TestName:  t.Name(),
-		HomeDir:   home,
 		Client:    client,
 		NetworkID: network,
 	}))
@@ -234,7 +228,6 @@ func TestCosmosChain_BroadcastTx(t *testing.T) {
 
 	t.Parallel()
 
-	home := ibctest.TempDir(t)
 	client, network := ibctest.DockerSetup(t)
 
 	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
@@ -270,7 +263,6 @@ func TestCosmosChain_BroadcastTx(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
 		TestName:  t.Name(),
-		HomeDir:   home,
 		Client:    client,
 		NetworkID: network,
 	}))
@@ -314,7 +306,6 @@ func TestInterchain_OmitGitSHA(t *testing.T) {
 
 	t.Parallel()
 
-	home := ibctest.TempDir(t)
 	client, network := ibctest.DockerSetup(t)
 
 	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
@@ -333,7 +324,6 @@ func TestInterchain_OmitGitSHA(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
 		TestName:  t.Name(),
-		HomeDir:   home,
 		Client:    client,
 		NetworkID: network,
 

--- a/internal/blockdb/messages_view_test.go
+++ b/internal/blockdb/messages_view_test.go
@@ -26,7 +26,6 @@ func TestMessagesView(t *testing.T) {
 
 	t.Parallel()
 
-	home := ibctest.TempDir(t)
 	client, network := ibctest.DockerSetup(t)
 
 	const gaia0ChainID = "g0"
@@ -63,7 +62,6 @@ func TestMessagesView(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
 		TestName:  t.Name(),
-		HomeDir:   home,
 		Client:    client,
 		NetworkID: network,
 

--- a/test_setup.go
+++ b/test_setup.go
@@ -49,7 +49,6 @@ func StartChainPairAndRelayer(
 	rep *testreporter.Reporter,
 	cli *client.Client,
 	networkID string,
-	home string,
 	srcChain, dstChain ibc.Chain,
 	f RelayerFactory,
 	preRelayerStartFuncs []func([]ibc.ChannelOutput),
@@ -77,7 +76,6 @@ func StartChainPairAndRelayer(
 	eRep := rep.RelayerExecReporter(t)
 	if err := ic.Build(ctx, eRep, InterchainBuildOptions{
 		TestName:          t.Name(),
-		HomeDir:           home,
 		Client:            cli,
 		NetworkID:         networkID,
 		GitSha:            version.GitSha,


### PR DESCRIPTION
Now that we are using Docker volumes everywhere, the home directory is
unused and is no longer necessary for the Chain.Initialize method.

Also plumb context through to address a couple context.TODO calls.
