### PR TITLE
Polkadot ChainFactory, ChainSpec, and test

### DIFF
--- a/chain/polkadot/polkadot_chain_test.go
+++ b/chain/polkadot/polkadot_chain_test.go
@@ -1,0 +1,53 @@
+package polkadot_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/test"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestPolkadotComposableChainStart(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Parallel()
+
+	client, network := ibctest.DockerSetup(t)
+
+	nv := 5
+	nf := 3
+
+	chains, err := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
+		{
+			Name:    "composable",
+			Version: "polkadot:v0.9.19,composable:v2.1.9",
+			ChainConfig: ibc.ChainConfig{
+				ChainID: "rococo-local",
+			},
+			NumValidators: &nv,
+			NumFullNodes:  &nf,
+		},
+	},
+	).Chains(t.Name())
+
+	require.NoError(t, err, "failed to get polkadot chain")
+	require.Len(t, chains, 1)
+	chain := chains[0]
+
+	ctx := context.Background()
+
+	err = chain.Initialize(ctx, t.Name(), client, network)
+	require.NoError(t, err, "failed to initialize polkadot chain")
+
+	err = chain.Start(t.Name(), ctx)
+	require.NoError(t, err, "failed to start polkadot chain")
+
+	err = test.WaitForBlocks(ctx, 10, chain)
+	require.NoError(t, err, "polkadot chain failed to make blocks")
+}


### PR DESCRIPTION
Wires up `polkadot` chain in `ChainFactory`, only handling `composable` as a supported parachain for now.

Adds config overrides in `ChainSpec` for `polkadot` to configure the docker image versions.

Adds test for polkadot chain to ensure relay chain and parachain can start and that composable chain produces 10 blocks.