### PR TITLE
Make events default rly start method

### DIFF
--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -204,6 +204,8 @@ func (commander) RestoreKey(chainID, keyName, mnemonic, homeDir string) []string
 func (c commander) StartRelayer(pathName, homeDir string) []string {
 	cmd := []string{
 		"rly", "start", pathName, "--debug",
+		"-p", "events",
+		"-b", "50",
 		"--home", homeDir,
 	}
 	cmd = append(cmd, c.extraStartFlags...)


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR makes the `-p events` flag the default method for starting `rly`.

I kept running the tests consecutively and without adding a slightly greater initial block history the tests were failing intermittenly.

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project


