### PR TITLE
Add cosmos state sync test

### DIFF
--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -20,6 +20,7 @@ import (
 	"github.com/strangelove-ventures/ibctest/chain/internal/tendermint"
 	"github.com/strangelove-ventures/ibctest/ibc"
 	"github.com/strangelove-ventures/ibctest/internal/blockdb"
+	"github.com/strangelove-ventures/ibctest/internal/configutil"
 	"github.com/strangelove-ventures/ibctest/internal/dockerutil"
 	"github.com/strangelove-ventures/ibctest/test"
 	"go.uber.org/zap"
@@ -112,11 +113,19 @@ func (c *CosmosChain) AddFullNodes(ctx context.Context, configFileOverrides map[
 				return err
 			}
 			for configFile, modifiedConfig := range configFileOverrides {
-				modifiedToml, ok := modifiedConfig.(DecodedToml)
+				modifiedToml, ok := modifiedConfig.(configutil.Toml)
 				if !ok {
 					return fmt.Errorf("Provided toml override for file %s is of type (%T). Expected (DecodedToml)", configFile, modifiedConfig)
 				}
-				if err := fn.ModifyTomlConfigFile(ctx, configFile, modifiedToml); err != nil {
+				if err := configutil.ModifyTomlConfigFile(
+					ctx,
+					fn.logger(),
+					fn.DockerClient,
+					fn.TestName,
+					fn.VolumeName,
+					configFile,
+					modifiedToml,
+				); err != nil {
 					return err
 				}
 			}
@@ -517,11 +526,19 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 				return err
 			}
 			for configFile, modifiedConfig := range configFileOverrides {
-				modifiedToml, ok := modifiedConfig.(DecodedToml)
+				modifiedToml, ok := modifiedConfig.(configutil.Toml)
 				if !ok {
 					return fmt.Errorf("Provided toml override for file %s is of type (%T). Expected (DecodedToml)", configFile, modifiedConfig)
 				}
-				if err := v.ModifyTomlConfigFile(ctx, configFile, modifiedToml); err != nil {
+				if err := configutil.ModifyTomlConfigFile(
+					ctx,
+					v.logger(),
+					v.DockerClient,
+					v.TestName,
+					v.VolumeName,
+					configFile,
+					modifiedToml,
+				); err != nil {
 					return err
 				}
 			}
@@ -538,11 +555,19 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 				return err
 			}
 			for configFile, modifiedConfig := range configFileOverrides {
-				modifiedToml, ok := modifiedConfig.(DecodedToml)
+				modifiedToml, ok := modifiedConfig.(configutil.Toml)
 				if !ok {
 					return fmt.Errorf("Provided toml override for file %s is of type (%T). Expected (DecodedToml)", configFile, modifiedConfig)
 				}
-				if err := n.ModifyTomlConfigFile(ctx, configFile, modifiedToml); err != nil {
+				if err := configutil.ModifyTomlConfigFile(
+					ctx,
+					n.logger(),
+					n.DockerClient,
+					n.TestName,
+					n.VolumeName,
+					configFile,
+					modifiedToml,
+				); err != nil {
 					return err
 				}
 			}

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -33,7 +33,8 @@ type CosmosChain struct {
 	cfg           ibc.ChainConfig
 	numValidators int
 	numFullNodes  int
-	ChainNodes    ChainNodes
+	Validators    ChainNodes
+	FullNodes     ChainNodes
 
 	log *zap.Logger
 }
@@ -74,6 +75,60 @@ func NewCosmosChain(testName string, chainConfig ibc.ChainConfig, numValidators 
 	}
 }
 
+// Nodes returns all nodes, including validators and fullnodes.
+func (c *CosmosChain) Nodes() ChainNodes {
+	return append(c.Validators, c.FullNodes...)
+}
+
+// AddFullNodes adds new fullnodes to the network, peering with the existing nodes.
+func (c *CosmosChain) AddFullNodes(ctx context.Context, configFileOverrides map[string]any, inc int) error {
+	// Get peer string for existing nodes
+	peers := c.Nodes().PeerString(ctx)
+
+	// Get genesis.json
+	genbz, err := c.Validators[0].genesisFileContent(ctx)
+	if err != nil {
+		return err
+	}
+
+	prevCount := c.numFullNodes
+	c.numFullNodes += inc
+	if err := c.initializeChainNodes(ctx, c.testName, c.getFullNode().DockerClient, c.getFullNode().NetworkID); err != nil {
+		return err
+	}
+
+	var eg errgroup.Group
+	for i := prevCount; i < c.numFullNodes; i++ {
+		i := i
+		eg.Go(func() error {
+			fn := c.FullNodes[i]
+			if err := fn.InitFullNodeFiles(ctx); err != nil {
+				return err
+			}
+			if err := fn.SetPeers(ctx, peers); err != nil {
+				return err
+			}
+			if err := fn.overwriteGenesisFile(ctx, genbz); err != nil {
+				return err
+			}
+			for configFile, modifiedConfig := range configFileOverrides {
+				modifiedToml, ok := modifiedConfig.(DecodedToml)
+				if !ok {
+					return fmt.Errorf("Provided toml override for file %s is of type (%T). Expected (DecodedToml)", configFile, modifiedConfig)
+				}
+				if err := fn.ModifyTomlConfigFile(ctx, configFile, modifiedToml); err != nil {
+					return err
+				}
+			}
+			if err := fn.CreateNodeContainer(ctx); err != nil {
+				return err
+			}
+			return fn.StartContainer(ctx)
+		})
+	}
+	return eg.Wait()
+}
+
 // Implements Chain interface
 func (c *CosmosChain) Config() ibc.ChainConfig {
 	return c.cfg
@@ -85,12 +140,12 @@ func (c *CosmosChain) Initialize(ctx context.Context, testName string, cli *clie
 }
 
 func (c *CosmosChain) getFullNode() *ChainNode {
-	if len(c.ChainNodes) > c.numValidators {
+	if len(c.FullNodes) > 0 {
 		// use first full node
-		return c.ChainNodes[c.numValidators]
+		return c.FullNodes[0]
 	}
 	// use first validator
-	return c.ChainNodes[0]
+	return c.Validators[0]
 }
 
 // Exec implements ibc.Chain.
@@ -289,7 +344,10 @@ func (c *CosmosChain) GetGasFeesInNativeDenom(gasPaid int64) int64 {
 
 func (c *CosmosChain) UpgradeVersion(ctx context.Context, cli *client.Client, version string) {
 	c.cfg.Images[0].Version = version
-	for _, n := range c.ChainNodes {
+	for _, n := range c.Validators {
+		n.Image.Version = version
+	}
+	for _, n := range c.FullNodes {
 		n.Image.Version = version
 	}
 	c.pullImages(ctx, cli)
@@ -315,6 +373,55 @@ func (c *CosmosChain) pullImages(ctx context.Context, cli *client.Client) {
 	}
 }
 
+// NewChainNode constructs a new cosmos chain node with a docker volume.
+func (c *CosmosChain) NewChainNode(
+	ctx context.Context,
+	testName string,
+	cli *client.Client,
+	networkID string,
+	image ibc.DockerImage,
+	validator bool,
+) (*ChainNode, error) {
+	// Construct the ChainNode first so we can access its name.
+	// The ChainNode's VolumeName cannot be set until after we create the volume.
+	tn := &ChainNode{
+		log: c.log,
+
+		Validator: validator,
+
+		Chain:        c,
+		DockerClient: cli,
+		NetworkID:    networkID,
+		TestName:     testName,
+		Image:        image,
+	}
+
+	v, err := cli.VolumeCreate(ctx, volumetypes.VolumeCreateBody{
+		Labels: map[string]string{
+			dockerutil.CleanupLabel: testName,
+
+			dockerutil.NodeOwnerLabel: tn.Name(),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating volume for chain node: %w", err)
+	}
+	tn.VolumeName = v.Name
+
+	if err := dockerutil.SetVolumeOwner(ctx, dockerutil.VolumeOwnerOptions{
+		Log: c.log,
+
+		Client: cli,
+
+		VolumeName: v.Name,
+		ImageRef:   image.Ref(),
+		TestName:   testName,
+	}); err != nil {
+		return nil, fmt.Errorf("set volume owner: %w", err)
+	}
+	return tn, nil
+}
+
 // creates the test node objects required for bootstrapping tests
 func (c *CosmosChain) initializeChainNodes(
 	ctx context.Context,
@@ -322,61 +429,38 @@ func (c *CosmosChain) initializeChainNodes(
 	cli *client.Client,
 	networkID string,
 ) error {
-	count := c.numValidators + c.numFullNodes
 	chainCfg := c.Config()
 	c.pullImages(ctx, cli)
 	image := chainCfg.Images[0]
-	chainNodes := make([]*ChainNode, count)
+
 	eg, egCtx := errgroup.WithContext(ctx)
-	for i := 0; i < count; i++ {
+	for i := len(c.Validators); i < c.numValidators; i++ {
 		i := i
 		eg.Go(func() error {
-			// Construct the ChainNode first so we can access its name.
-			// The ChainNode's VolumeName cannot be set until after we create the volume.
-			tn := &ChainNode{
-				log: c.log,
-
-				Index:        i,
-				Chain:        c,
-				DockerClient: cli,
-				NetworkID:    networkID,
-				TestName:     testName,
-				Image:        image,
-			}
-
-			v, err := cli.VolumeCreate(egCtx, volumetypes.VolumeCreateBody{
-				Labels: map[string]string{
-					dockerutil.CleanupLabel: testName,
-
-					dockerutil.NodeOwnerLabel: tn.Name(),
-				},
-			})
+			val, err := c.NewChainNode(egCtx, testName, cli, networkID, image, true)
 			if err != nil {
-				return fmt.Errorf("creating volume for chain node: %w", err)
+				return err
 			}
-			tn.VolumeName = v.Name
-
-			if err := dockerutil.SetVolumeOwner(ctx, dockerutil.VolumeOwnerOptions{
-				Log: c.log,
-
-				Client: cli,
-
-				VolumeName: v.Name,
-				ImageRef:   image.Ref(),
-				TestName:   testName,
-			}); err != nil {
-				return fmt.Errorf("set volume owner: %w", err)
+			val.Index = i
+			c.Validators = append(c.Validators, val)
+			return nil
+		})
+	}
+	for i := len(c.FullNodes); i < c.numFullNodes; i++ {
+		i := i
+		eg.Go(func() error {
+			fn, err := c.NewChainNode(egCtx, testName, cli, networkID, image, false)
+			if err != nil {
+				return err
 			}
-
-			chainNodes[i] = tn
-
+			fn.Index = i
+			c.FullNodes = append(c.FullNodes, fn)
 			return nil
 		})
 	}
 	if err := eg.Wait(); err != nil {
 		return err
 	}
-	c.ChainNodes = chainNodes
 	return nil
 }
 
@@ -421,24 +505,49 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 
 	genesisAmounts := []types.Coin{genesisAmount, genesisStakeAmount}
 
-	validators := c.ChainNodes[:c.numValidators]
-	fullnodes := c.ChainNodes[c.numValidators:]
+	configFileOverrides := chainCfg.ConfigFileOverrides
 
 	eg := new(errgroup.Group)
-	// sign gentx for each validator
-	for _, v := range validators {
+	// Initialize config and sign gentx for each validator.
+	for _, v := range c.Validators {
 		v := v
 		v.Validator = true
 		eg.Go(func() error {
-			return v.InitValidatorFiles(ctx, &chainCfg, genesisAmounts, genesisSelfDelegation)
+			if err := v.InitFullNodeFiles(ctx); err != nil {
+				return err
+			}
+			for configFile, modifiedConfig := range configFileOverrides {
+				modifiedToml, ok := modifiedConfig.(DecodedToml)
+				if !ok {
+					return fmt.Errorf("Provided toml override for file %s is of type (%T). Expected (DecodedToml)", configFile, modifiedConfig)
+				}
+				if err := v.ModifyTomlConfigFile(ctx, configFile, modifiedToml); err != nil {
+					return err
+				}
+			}
+			return v.InitValidatorGenTx(ctx, &chainCfg, genesisAmounts, genesisSelfDelegation)
 		})
 	}
 
-	// just initialize folder for any full nodes
-	for _, n := range fullnodes {
+	// Initialize config for each full node.
+	for _, n := range c.FullNodes {
 		n := n
 		n.Validator = false
-		eg.Go(func() error { return n.InitFullNodeFiles(ctx) })
+		eg.Go(func() error {
+			if err := n.InitFullNodeFiles(ctx); err != nil {
+				return err
+			}
+			for configFile, modifiedConfig := range configFileOverrides {
+				modifiedToml, ok := modifiedConfig.(DecodedToml)
+				if !ok {
+					return fmt.Errorf("Provided toml override for file %s is of type (%T). Expected (DecodedToml)", configFile, modifiedConfig)
+				}
+				if err := n.ModifyTomlConfigFile(ctx, configFile, modifiedToml); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 	}
 
 	// wait for this to finish
@@ -448,9 +557,9 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 
 	// for the validators we need to collect the gentxs and the accounts
 	// to the first node's genesis file
-	validator0 := validators[0]
-	for i := 1; i < len(validators); i++ {
-		validatorN := validators[i]
+	validator0 := c.Validators[0]
+	for i := 1; i < len(c.Validators); i++ {
+		validatorN := c.Validators[i]
 
 		bech32, err := validatorN.KeyBech32(ctx, valKey)
 		if err != nil {
@@ -494,18 +603,20 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 		_ = os.WriteFile(exportGenesis, genbz, 0600)
 	}
 
-	for _, cn := range c.ChainNodes {
+	chainNodes := c.Nodes()
+
+	for _, cn := range chainNodes {
 		if err := cn.overwriteGenesisFile(ctx, genbz); err != nil {
 			return err
 		}
 	}
 
-	if err := c.ChainNodes.LogGenesisHashes(ctx); err != nil {
+	if err := chainNodes.LogGenesisHashes(ctx); err != nil {
 		return err
 	}
 
 	eg, egCtx := errgroup.WithContext(ctx)
-	for _, n := range c.ChainNodes {
+	for _, n := range chainNodes {
 		n := n
 		eg.Go(func() error {
 			return n.CreateNodeContainer(egCtx)
@@ -515,14 +626,14 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 		return err
 	}
 
-	peers := c.ChainNodes.PeerString(ctx)
+	peers := chainNodes.PeerString(ctx)
 
 	eg, egCtx = errgroup.WithContext(ctx)
-	for _, n := range c.ChainNodes {
+	for _, n := range chainNodes {
 		n := n
 		c.log.Info("Starting container", zap.String("container", n.Name()))
 		eg.Go(func() error {
-			if err := n.SetValidatorConfigAndPeers(egCtx, peers); err != nil {
+			if err := n.SetPeers(egCtx, peers); err != nil {
 				return err
 			}
 			return n.StartContainer(egCtx)
@@ -630,7 +741,7 @@ func (c *CosmosChain) FindTxs(ctx context.Context, height uint64) ([]blockdb.Tx,
 // StopAllNodes stops and removes all long running containers (validators and full nodes)
 func (c *CosmosChain) StopAllNodes(ctx context.Context) error {
 	var eg errgroup.Group
-	for _, n := range c.ChainNodes {
+	for _, n := range c.Nodes() {
 		n := n
 		eg.Go(func() error {
 			if err := n.StopContainer(ctx); err != nil {
@@ -646,7 +757,7 @@ func (c *CosmosChain) StopAllNodes(ctx context.Context) error {
 // Should only be used if the chain has previously been started with .Start.
 func (c *CosmosChain) StartAllNodes(ctx context.Context) error {
 	var eg errgroup.Group
-	for _, n := range c.ChainNodes {
+	for _, n := range c.Nodes() {
 		n := n
 		eg.Go(func() error {
 			if err := n.CreateNodeContainer(ctx); err != nil {
@@ -660,7 +771,7 @@ func (c *CosmosChain) StartAllNodes(ctx context.Context) error {
 
 func (c *CosmosChain) VoteOnProposalAllValidators(ctx context.Context, proposalID string, vote string) error {
 	var eg errgroup.Group
-	for _, n := range c.ChainNodes {
+	for _, n := range c.Nodes() {
 		if n.Validator {
 			n := n
 			eg.Go(func() error {

--- a/chainspec.go
+++ b/chainspec.go
@@ -31,8 +31,6 @@ type ChainSpec struct {
 	GasAdjustment *float64
 	NoHostMount   *bool
 
-	ModifyGenesis func([]byte) ([]byte, error)
-
 	// Embedded ChainConfig to allow for simple JSON definition of a ChainSpec.
 	ibc.ChainConfig
 

--- a/examples/state_sync_test.go
+++ b/examples/state_sync_test.go
@@ -1,0 +1,116 @@
+package ibctest_test
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/chain/cosmos"
+	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/test"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestCosmosHubStateSync(t *testing.T) {
+	CosmosChainStateSyncTest(t, "gaia", "v7.0.3")
+}
+
+const stateSyncSnapshotInterval = 10
+
+func CosmosChainStateSyncTest(t *testing.T, chainName, version string) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Parallel()
+
+	nf := 1
+
+	configFileOverrides := make(map[string]any)
+	appTomlOverrides := make(cosmos.DecodedToml)
+
+	// state sync snapshots every stateSyncSnapshotInterval blocks.
+	stateSync := make(cosmos.DecodedToml)
+	stateSync["snapshot-interval"] = stateSyncSnapshotInterval
+	appTomlOverrides["state-sync"] = stateSync
+
+	// state sync snapshot interval must be a multiple of pruning keep every interval.
+	appTomlOverrides["pruning"] = "custom"
+	appTomlOverrides["pruning-keep-recent"] = stateSyncSnapshotInterval
+	appTomlOverrides["pruning-keep-every"] = stateSyncSnapshotInterval
+	appTomlOverrides["pruning-interval"] = stateSyncSnapshotInterval
+
+	configFileOverrides["config/app.toml"] = appTomlOverrides
+
+	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
+		{
+			Name:      chainName,
+			ChainName: chainName,
+			Version:   version,
+			ChainConfig: ibc.ChainConfig{
+				ConfigFileOverrides: configFileOverrides,
+			},
+			NumFullNodes: &nf,
+		},
+	})
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+
+	chain := chains[0].(*cosmos.CosmosChain)
+
+	ic := ibctest.NewInterchain().
+		AddChain(chain)
+
+	ctx := context.Background()
+	client, network := ibctest.DockerSetup(t)
+
+	require.NoError(t, ic.Build(ctx, nil, ibctest.InterchainBuildOptions{
+		TestName:          t.Name(),
+		Client:            client,
+		NetworkID:         network,
+		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
+		SkipPathCreation:  true,
+	}))
+
+	// Wait for blocks so that nodes have a few state sync snapshot available
+	require.NoError(t, test.WaitForBlocks(ctx, stateSyncSnapshotInterval*2, chain))
+
+	latestHeight, err := chain.Height(ctx)
+	require.NoError(t, err, "failed to fetch latest chain height")
+
+	// Trusted height should be state sync snapshot interval blocks ago.
+	trustHeight := int64(latestHeight) - stateSyncSnapshotInterval
+
+	firstFullNode := chain.FullNodes[0]
+
+	// Fetch block hash for trusted height.
+	blockRes, err := firstFullNode.Client.Block(ctx, &trustHeight)
+	require.NoError(t, err, "failed to fetch trusted block")
+	trustHash := hex.EncodeToString(blockRes.BlockID.Hash)
+
+	// Construct statesync parameters for new node to get in sync.
+	configFileOverrides = make(map[string]any)
+	configTomlOverrides := make(cosmos.DecodedToml)
+
+	// Set trusted parameters and rpc servers for verification.
+	stateSync = make(cosmos.DecodedToml)
+	stateSync["trust_hash"] = trustHash
+	stateSync["trust_height"] = trustHeight
+	stateSync["rpc_servers"] = fmt.Sprintf("tcp://%s:26657,tcp://%s:26657", firstFullNode.HostName(), firstFullNode.HostName())
+	configTomlOverrides["statesync"] = stateSync
+
+	configFileOverrides["config/config.toml"] = configTomlOverrides
+
+	// Now that nodes are providing state sync snapshots, state sync a new node.
+	require.NoError(t, chain.AddFullNodes(ctx, configFileOverrides, 1))
+
+	// Wait for new node to be in sync.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	require.NoError(t, test.WaitForInSync(ctx, chain, chain.FullNodes[len(chain.FullNodes)-1]))
+}

--- a/examples/state_sync_test.go
+++ b/examples/state_sync_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/strangelove-ventures/ibctest"
 	"github.com/strangelove-ventures/ibctest/chain/cosmos"
 	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/internal/configutil"
 	"github.com/strangelove-ventures/ibctest/test"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -31,10 +32,10 @@ func CosmosChainStateSyncTest(t *testing.T, chainName, version string) {
 	nf := 1
 
 	configFileOverrides := make(map[string]any)
-	appTomlOverrides := make(cosmos.DecodedToml)
+	appTomlOverrides := make(configutil.Toml)
 
 	// state sync snapshots every stateSyncSnapshotInterval blocks.
-	stateSync := make(cosmos.DecodedToml)
+	stateSync := make(configutil.Toml)
 	stateSync["snapshot-interval"] = stateSyncSnapshotInterval
 	appTomlOverrides["state-sync"] = stateSync
 
@@ -95,12 +96,13 @@ func CosmosChainStateSyncTest(t *testing.T, chainName, version string) {
 
 	// Construct statesync parameters for new node to get in sync.
 	configFileOverrides = make(map[string]any)
-	configTomlOverrides := make(cosmos.DecodedToml)
+	configTomlOverrides := make(configutil.Toml)
 
 	// Set trusted parameters and rpc servers for verification.
-	stateSync = make(cosmos.DecodedToml)
+	stateSync = make(configutil.Toml)
 	stateSync["trust_hash"] = trustHash
 	stateSync["trust_height"] = trustHeight
+	// State sync requires minimum of two RPC servers for verification. We can provide the same RPC twice though.
 	stateSync["rpc_servers"] = fmt.Sprintf("tcp://%s:26657,tcp://%s:26657", firstFullNode.HostName(), firstFullNode.HostName())
 	configTomlOverrides["statesync"] = stateSync
 

--- a/examples/upgrade_test.go
+++ b/examples/upgrade_test.go
@@ -35,10 +35,12 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeVers
 
 	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
 		{
-			Name:          chainName,
-			ChainName:     chainName,
-			Version:       initialVersion,
-			ModifyGenesis: modifyGenesisVotingPeriod(votingPeriod),
+			Name:      chainName,
+			ChainName: chainName,
+			Version:   initialVersion,
+			ChainConfig: ibc.ChainConfig{
+				ModifyGenesis: modifyGenesisVotingPeriod(votingPeriod),
+			},
 		},
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.1 // indirect
+	github.com/BurntSushi/toml v1.2.0 // indirect
 	github.com/ChainSafe/go-schnorrkel v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/armon/go-metrics v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
+github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -31,6 +31,8 @@ type ChainConfig struct {
 	NoHostMount bool
 	// When provided, genesis file contents will be altered before sharing for genesis.
 	ModifyGenesis func([]byte) ([]byte, error)
+	// Override config parameters for files at filepath.
+	ConfigFileOverrides map[string]any
 }
 
 func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
@@ -78,6 +80,10 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 
 	if other.ModifyGenesis != nil {
 		c.ModifyGenesis = other.ModifyGenesis
+	}
+
+	if other.ConfigFileOverrides != nil {
+		c.ConfigFileOverrides = other.ConfigFileOverrides
 	}
 
 	return c

--- a/internal/configutil/toml.go
+++ b/internal/configutil/toml.go
@@ -1,0 +1,81 @@
+package configutil
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/BurntSushi/toml"
+	"github.com/docker/docker/client"
+	"github.com/strangelove-ventures/ibctest/internal/dockerutil"
+	"go.uber.org/zap"
+)
+
+// Toml is used for holding the decoded state of a toml config file.
+type Toml map[string]any
+
+// recursiveModifyToml will apply toml modifications at the current depth,
+// then recurse for new depths.
+func recursiveModifyToml(c map[string]any, modifications Toml) error {
+	for key, value := range modifications {
+		if reflect.ValueOf(value).Kind() == reflect.Map {
+			cV, ok := c[key]
+			if !ok {
+				// Did not find section in existing config, populating fresh.
+				cV = make(Toml)
+			}
+			// Retrieve existing config to apply overrides to.
+			cVM, ok := cV.(map[string]any)
+			if !ok {
+				return fmt.Errorf("failed to convert section to (map[string]any), found (%T)", cV)
+			}
+			if err := recursiveModifyToml(cVM, value.(Toml)); err != nil {
+				return err
+			}
+			c[key] = cVM
+		} else {
+			// Not a map, so we can set override value directly.
+			c[key] = value
+		}
+	}
+	return nil
+}
+
+// ModifyTomlConfigFile reads, modifies, then overwrites a toml config file, useful for config.toml, app.toml, etc.
+func ModifyTomlConfigFile(
+	ctx context.Context,
+	logger *zap.Logger,
+	dockerClient *client.Client,
+	testName string,
+	volumeName string,
+	filePath string,
+	modifications Toml,
+) error {
+	fr := dockerutil.NewFileRetriever(logger, dockerClient, testName)
+	config, err := fr.SingleFileContent(ctx, volumeName, filePath)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve %s: %w", filePath, err)
+	}
+
+	var c Toml
+	if err := toml.Unmarshal(config, &c); err != nil {
+		return fmt.Errorf("failed to unmarshal %s: %w", filePath, err)
+	}
+
+	if err := recursiveModifyToml(c, modifications); err != nil {
+		return err
+	}
+
+	buf := new(bytes.Buffer)
+	if err := toml.NewEncoder(buf).Encode(c); err != nil {
+		return err
+	}
+
+	fw := dockerutil.NewFileWriter(logger, dockerClient, testName)
+	if err := fw.WriteFile(ctx, volumeName, filePath, buf.Bytes()); err != nil {
+		return fmt.Errorf("overwriting %s: %w", filePath, err)
+	}
+
+	return nil
+}

--- a/test/wait_for_blocks.go
+++ b/test/wait_for_blocks.go
@@ -29,42 +29,50 @@ func WaitForBlocks(ctx context.Context, delta int, chains ...ChainHeighter) erro
 	return eg.Wait()
 }
 
+// nodesInSync returns an error if the nodes are not in sync with the chain.
+func nodesInSync(ctx context.Context, chain ChainHeighter, nodes []ChainHeighter) error {
+	var chainHeight uint64
+	nodeHeights := make([]uint64, len(nodes))
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(func() (err error) {
+		chainHeight, err = chain.Height(egCtx)
+		return err
+	})
+	for i, n := range nodes {
+		i := i
+		n := n
+		eg.Go(func() (err error) {
+			nodeHeights[i], err = n.Height(egCtx)
+			return err
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	for _, h := range nodeHeights {
+		if h < chainHeight {
+			return fmt.Errorf("Node is not yet in sync: %d < %d", h, chainHeight)
+		}
+	}
+	// all nodes >= chainHeight
+	return nil
+}
+
 // WaitForInSync blocks until all nodes have heights greater than or equal to the chain height.
 func WaitForInSync(ctx context.Context, chain ChainHeighter, nodes ...ChainHeighter) error {
 	if len(nodes) == 0 {
 		panic("missing nodes")
 	}
-InSyncLoop:
 	for {
-		if ctx.Err() != nil {
-			return fmt.Errorf("timed out waiting for node(s) to be in sync: %w", ctx.Err())
-		}
-		var chainHeight uint64
-		nodeHeights := make([]uint64, len(nodes))
-		eg, egCtx := errgroup.WithContext(ctx)
-		eg.Go(func() (err error) {
-			chainHeight, err = chain.Height(egCtx)
-			return err
-		})
-		for i, n := range nodes {
-			i := i
-			n := n
-			eg.Go(func() (err error) {
-				nodeHeights[i], err = n.Height(egCtx)
-				return err
-			})
-		}
-		if err := eg.Wait(); err != nil {
-			return err
-		}
-		for _, h := range nodeHeights {
-			if h < chainHeight {
-				fmt.Printf("Node height %d is less than chain height %d\n", h, chainHeight)
-				continue InSyncLoop
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if err := nodesInSync(ctx, chain, nodes); err != nil {
+				continue
 			}
+			return nil
 		}
-		// all nodes >= chainHeight
-		return nil
 	}
 }
 


### PR DESCRIPTION
Adds a cosmos chain state sync test to the examples:
- Start chain using a short state-sync snapshot interval of 10 blocks
- Wait for chain to produce twice as many blocks
- Fetch latest height from chain, then subtract snapshot interval for trusted height
- Fetch block ID hash for the trusted height
- Add new full node with statesync params `trust_hash` and `trusted_height` for the proof of trusted height, and `rpc_servers` for verification, which is just the first full node twice.
- Wait for new full node to complete state sync and get in sync with the chain

Cleanup:
- Instead of overwriting the tendermint config.toml when setting peers, we can use the config.toml that was generated during the config init step. The config changes can be applied overtop using [BurntSushi/toml](github.com/BurntSushi/toml). 
- Adds `ConfigFileOverrides` to the ibc `ChainConfig` type to provide config overrides, needed to configure initial state sync params. This is dynamic enough that it can apply to all chains, since the type is `map[string]any`, a mapping from the config filepath relative the mounted docker volume director to the override configuration type. For cosmos chains, the type is expected to be `cosmos.DecodedToml`. Other chains can handle this as they wish, and also future handling could be added if cosmos chains would need to handle more than just toml configuration files.
- Breaks apart cosmos chain `ChainNodes` into `Validators` and `FullNodes`, which makes the separation more specific, makes the container names more clear, and paved the way for the cosmos chain `AddFullNodes` method to add new nodes during runtime.



