### PR TITLE
return error on failed ibc transfers

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -445,6 +445,8 @@ func (tn *ChainNode) CollectGentxs(ctx context.Context) error {
 
 type CosmosTx struct {
 	TxHash string `json:"txhash"`
+	Code   int    `json:"code"`
+	RawLog string `json:"raw_log"`
 }
 
 func (tn *ChainNode) SendIBCTransfer(ctx context.Context, channelID string, keyName string, amount ibc.WalletAmount, timeout *ibc.IBCTimeout) (string, error) {
@@ -479,6 +481,9 @@ func (tn *ChainNode) SendIBCTransfer(ctx context.Context, channelID string, keyN
 	}
 	output := CosmosTx{}
 	err = json.Unmarshal([]byte(stdout), &output)
+	if output.Code != 0 {
+		return "", fmt.Errorf("failed to send ibc transfer tx: %s", output.RawLog)
+	}
 	return output.TxHash, err
 }
 


### PR DESCRIPTION
Returning this error should help troubleshoot failed IBC transfers. 

For example, if there are not enough funds in wallet to cover send-amount + gas.