### PR TITLE
Fix volume ownership when heighliner images don't have chown or chmod

### DIFF
--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -60,6 +60,7 @@ func NewCosmosHeighlinerChainConfig(name string,
 		Images: []ibc.DockerImage{
 			{
 				Repository: fmt.Sprintf("ghcr.io/strangelove-ventures/heighliner/%s", name),
+				UidGid:     dockerutil.GetHeighlinerUserString(),
 			},
 		},
 		Bin: binary,
@@ -425,7 +426,7 @@ func (c *CosmosChain) NewChainNode(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
-		Owner:      dockerutil.GetHeighlinerUserString(),
+		UidGid:     image.UidGid,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -425,6 +425,7 @@ func (c *CosmosChain) NewChainNode(
 		VolumeName: v.Name,
 		ImageRef:   image.Ref(),
 		TestName:   testName,
+		Owner:      dockerutil.GetHeighlinerUserString(),
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -69,9 +69,11 @@ func NewPenumbraChainConfig() ibc.ChainConfig {
 		Images: []ibc.DockerImage{
 			{
 				Repository: "ghcr.io/strangelove-ventures/heighliner/tendermint",
+				UidGid:     dockerutil.GetHeighlinerUserString(),
 			},
 			{
 				Repository: "ghcr.io/strangelove-ventures/heighliner/penumbra",
+				UidGid:     dockerutil.GetHeighlinerUserString(),
 			},
 		},
 		Bin: "tendermint",
@@ -265,6 +267,7 @@ func (c *PenumbraChain) initializeChainNodes(
 			VolumeName: tn.VolumeName,
 			ImageRef:   tn.Image.Ref(),
 			TestName:   tn.TestName,
+			UidGid:     tn.Image.UidGid,
 		}); err != nil {
 			return fmt.Errorf("set tendermint volume owner: %w", err)
 		}
@@ -290,6 +293,7 @@ func (c *PenumbraChain) initializeChainNodes(
 			VolumeName: pn.VolumeName,
 			ImageRef:   pn.Image.Ref(),
 			TestName:   pn.TestName,
+			UidGid:     tn.Image.UidGid,
 		}); err != nil {
 			return fmt.Errorf("set penumbra volume owner: %w", err)
 		}

--- a/chain/polkadot/polkadot_chain.go
+++ b/chain/polkadot/polkadot_chain.go
@@ -78,9 +78,11 @@ func NewComposableChainConfig() ibc.ChainConfig {
 		Images: []ibc.DockerImage{
 			{
 				Repository: "ghcr.io/strangelove-ventures/heighliner/polkadot",
+				UidGid:     dockerutil.GetHeighlinerUserString(),
 			},
 			{
 				Repository: "ghcr.io/strangelove-ventures/heighliner/composable",
+				UidGid:     dockerutil.GetHeighlinerUserString(),
 			},
 		},
 		Bin: "polkadot",
@@ -191,6 +193,7 @@ func (c *PolkadotChain) Initialize(ctx context.Context, testName string, cli *cl
 			VolumeName: v.Name,
 			ImageRef:   chainCfg.Images[0].Ref(),
 			TestName:   testName,
+			UidGid:     chainCfg.Images[0].UidGid,
 		}); err != nil {
 			return fmt.Errorf("set volume owner: %w", err)
 		}
@@ -237,6 +240,7 @@ func (c *PolkadotChain) Initialize(ctx context.Context, testName string, cli *cl
 				VolumeName: v.Name,
 				ImageRef:   parachainConfig.Image.Ref(),
 				TestName:   testName,
+				UidGid:     parachainConfig.Image.UidGid,
 			}); err != nil {
 				return fmt.Errorf("set volume owner: %w", err)
 			}

--- a/cmd/ibctest/example_matrix_custom.json
+++ b/cmd/ibctest/example_matrix_custom.json
@@ -13,7 +13,8 @@
         "Images": [
           {
             "Repository": "ghcr.io/strangelove-ventures/heighliner/gaia",
-            "Version": "latest"
+            "Version": "latest",
+            "UidGid": "1025:1025"
           }
         ],
         "Bin": "gaiad",
@@ -32,7 +33,8 @@
         "Images": [
           {
             "Repository": "ghcr.io/strangelove-ventures/heighliner/osmosis",
-            "Version": "latest"
+            "Version": "latest",
+            "UidGid": "1025:1025"
           }
         ],
         "Bin": "osmosisd",

--- a/examples/interchain_queries_test.go
+++ b/examples/interchain_queries_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/icza/dyno"
 	"github.com/strangelove-ventures/ibctest"
 	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/internal/dockerutil"
 	"github.com/strangelove-ventures/ibctest/relayer"
 	"github.com/strangelove-ventures/ibctest/test"
 	"github.com/strangelove-ventures/ibctest/testreporter"
@@ -37,6 +38,7 @@ func TestInterchainQueries(t *testing.T) {
 	dockerImage := ibc.DockerImage{
 		Repository: "ghcr.io/strangelove-ventures/heighliner/icqd",
 		Version:    "latest",
+		UidGid:     dockerutil.GetHeighlinerUserString(),
 	}
 
 	// Get both chains

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -107,6 +107,7 @@ func (c ChainConfig) IsFullyConfigured() bool {
 type DockerImage struct {
 	Repository string
 	Version    string
+	UidGid     string
 }
 
 // Ref returns the reference to use when e.g. creating a container.

--- a/internal/dockerutil/volumeowner.go
+++ b/internal/dockerutil/volumeowner.go
@@ -20,14 +20,14 @@ type VolumeOwnerOptions struct {
 	VolumeName string
 	ImageRef   string
 	TestName   string
-	Owner      string
+	UidGid     string
 }
 
 // SetVolumeOwner configures the owner of a volume to match the default user in the supplied image reference.
 func SetVolumeOwner(ctx context.Context, opts VolumeOwnerOptions) error {
-	u := opts.Owner
-	if u == "" {
-		u = GetRootUserString()
+	owner := opts.UidGid
+	if owner == "" {
+		owner = GetRootUserString()
 	}
 
 	// Start a one-off container to chmod and chown the volume.
@@ -45,7 +45,7 @@ func SetVolumeOwner(ctx context.Context, opts VolumeOwnerOptions) error {
 				`chown "$2" "$1" && chmod 0700 "$1"`,
 				"_", // Meaningless arg0 for sh -c with positional args.
 				mountPath,
-				u,
+				owner,
 			},
 
 			// Root user so we have permissions to set ownership and mode.

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -414,6 +414,7 @@ func (r *DockerRelayer) containerImage() ibc.DockerImage {
 	return ibc.DockerImage{
 		Repository: r.c.DefaultContainerImage(),
 		Version:    r.c.DefaultContainerVersion(),
+		UidGid:     r.c.DockerUser(),
 	}
 }
 
@@ -608,8 +609,7 @@ type RelayerCommander interface {
 	DefaultContainerVersion() string
 
 	// The Docker user to use in created container.
-	// According to the Docker docs, this can be in format:
-	// <name|uid>[:<group|gid>].
+	// For ibctest, must be of the format: uid:gid.
 	DockerUser() string
 
 	// ConfigContent generates the content of the config file that will be passed to AddChainConfiguration.

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -101,6 +101,7 @@ func NewDockerRelayer(ctx context.Context, log *zap.Logger, testName string, cli
 		VolumeName: r.volumeName,
 		ImageRef:   containerImage.Ref(),
 		TestName:   testName,
+		UidGid:     containerImage.UidGid,
 	}); err != nil {
 		return nil, fmt.Errorf("set volume owner: %w", err)
 	}

--- a/relayer/options.go
+++ b/relayer/options.go
@@ -16,11 +16,12 @@ type RelayerOptionDockerImage struct {
 	DockerImage ibc.DockerImage
 }
 
-func CustomDockerImage(repository string, version string) RelayerOption {
+func CustomDockerImage(repository string, version string, uidGid string) RelayerOption {
 	return RelayerOptionDockerImage{
 		DockerImage: ibc.DockerImage{
 			Repository: repository,
 			Version:    version,
+			UidGid:     uidGid,
 		},
 	}
 }

--- a/relayer/options.go
+++ b/relayer/options.go
@@ -16,6 +16,9 @@ type RelayerOptionDockerImage struct {
 	DockerImage ibc.DockerImage
 }
 
+// CustomDockerImage overrides the default relayer docker image.
+// uidGid is the uid:gid format owner that should be used within the container.
+// If uidGid is empty, root user will be assumed.
 func CustomDockerImage(repository string, version string, uidGid string) RelayerOption {
 	return RelayerOptionDockerImage{
 		DockerImage: ibc.DockerImage{
@@ -44,6 +47,7 @@ type RelayerOptionExtraStartFlags struct {
 	Flags []string
 }
 
+// StartupFlags appends additional flags when starting the relayer.
 func StartupFlags(flags ...string) RelayerOption {
 	return RelayerOptionExtraStartFlags{
 		Flags: flags,

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -104,7 +104,7 @@ func (commander) Name() string {
 }
 
 func (commander) DockerUser() string {
-	return "rlyuser" // The name of the user according to rly's Dockerfile.
+	return "100:1000" // docker run -it --rm --entrypoint echo ghcr.io/cosmos/relayer "$(id -u):$(id -g)"
 }
 
 func (commander) AddChainConfiguration(containerFilePath, homeDir string) []string {


### PR DESCRIPTION
Problem: new slim heighliner images don't have `chown` or `chmod`.

Adds `UidGid` parameter to `ibc.DockerImage`. If empty, root user is assumed. If non-empty, `uid:gid` format is required so that busybox can change ownership without knowing the contents of the target image's `/etc/passwd`

With this, we don't need to assume that any other custom images would have `chown` or `chmod` either.