### PR TITLE
Fix fully configured custom chains

### DIFF
--- a/chainspec.go
+++ b/chainspec.go
@@ -70,13 +70,16 @@ func (s *ChainSpec) Config() (*ibc.ChainConfig, error) {
 	// Get built-in config.
 	cfg, ok := builtinChainConfigs[s.Name]
 	if !ok {
-		availableChains := make([]string, 0, len(builtinChainConfigs))
-		for k := range builtinChainConfigs {
-			availableChains = append(availableChains, k)
-		}
-		sort.Strings(availableChains)
+		if !s.ChainConfig.IsFullyConfigured() {
+			availableChains := make([]string, 0, len(builtinChainConfigs))
+			for k := range builtinChainConfigs {
+				availableChains = append(availableChains, k)
+			}
+			sort.Strings(availableChains)
 
-		return nil, fmt.Errorf("no chain configuration for %s (available chains are: %s)", s.Name, strings.Join(availableChains, ", "))
+			return nil, fmt.Errorf("no chain configuration for %s (available chains are: %s)", s.Name, strings.Join(availableChains, ", "))
+		}
+		cfg = ibc.ChainConfig{}
 	}
 
 	// Apply any overrides from this ChainSpec.

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -70,7 +70,9 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 		c.GasPrices = other.GasPrices
 	}
 
-	// Skip GasAdjustment, so that 0.0 can be distinguished.
+	if other.GasAdjustment > 0 && c.GasAdjustment == 0 {
+		c.GasAdjustment = other.GasAdjustment
+	}
 
 	if other.TrustingPeriod != "" {
 		c.TrustingPeriod = other.TrustingPeriod


### PR DESCRIPTION
Allows chain config to be constructed for non built in chains as long as they are fully configured.
Passes along gas adjustment value if non-zero