### PR TITLE
EncodingConfig override

### DIFF
--- a/chain/cosmos/broadcaster.go
+++ b/chain/cosmos/broadcaster.go
@@ -135,7 +135,7 @@ func (b *Broadcaster) GetTxResponseBytes(ctx context.Context, user User) ([]byte
 // instance of sdk.TxResponse.
 func (b *Broadcaster) UnmarshalTxResponseBytes(ctx context.Context, bytes []byte) (sdk.TxResponse, error) {
 	resp := sdk.TxResponse{}
-	if err := defaultEncoding.Codec.UnmarshalJSON(bytes, &resp); err != nil {
+	if err := b.chain.cfg.EncodingConfig.Codec.UnmarshalJSON(bytes, &resp); err != nil {
 		return sdk.TxResponse{}, err
 	}
 	return resp, nil
@@ -156,7 +156,7 @@ func (b *Broadcaster) defaultClientContext(fromUser User, sdkAdd sdk.AccAddress)
 		WithAccountRetriever(authtypes.AccountRetriever{}).
 		WithKeyring(kr).
 		WithBroadcastMode(flags.BroadcastBlock).
-		WithCodec(defaultEncoding.Codec)
+		WithCodec(b.chain.cfg.EncodingConfig.Codec)
 
 	// NOTE: the returned context used to have .WithHomeDir(cn.Home),
 	// but that field no longer exists and the test against Broadcaster still passes without it.

--- a/chain/cosmos/codec.go
+++ b/chain/cosmos/codec.go
@@ -2,6 +2,7 @@ package cosmos
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/simapp"
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	"github.com/cosmos/cosmos-sdk/std"
@@ -12,7 +13,7 @@ import (
 	ibctypes "github.com/cosmos/ibc-go/v5/modules/core/types"
 )
 
-func newTestEncoding() simappparams.EncodingConfig {
+func DefaultEncoding() simappparams.EncodingConfig {
 	// core modules
 	cfg := simappparams.MakeTestEncodingConfig()
 	std.RegisterLegacyAminoCodec(cfg.Amino)
@@ -28,16 +29,12 @@ func newTestEncoding() simappparams.EncodingConfig {
 	return cfg
 }
 
-var (
-	defaultEncoding = newTestEncoding()
-)
-
-func decodeTX(txbz []byte) (sdk.Tx, error) {
-	cdc := codec.NewProtoCodec(defaultEncoding.InterfaceRegistry)
+func decodeTX(interfaceRegistry codectypes.InterfaceRegistry, txbz []byte) (sdk.Tx, error) {
+	cdc := codec.NewProtoCodec(interfaceRegistry)
 	return authTx.DefaultTxDecoder(cdc)(txbz)
 }
 
-func encodeTxToJSON(tx sdk.Tx) ([]byte, error) {
-	cdc := codec.NewProtoCodec(defaultEncoding.InterfaceRegistry)
+func encodeTxToJSON(interfaceRegistry codectypes.InterfaceRegistry, tx sdk.Tx) ([]byte, error) {
+	cdc := codec.NewProtoCodec(interfaceRegistry)
 	return authTx.DefaultJSONTxEncoder(cdc)(tx)
 }

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -68,6 +68,10 @@ func NewCosmosHeighlinerChainConfig(name string,
 }
 
 func NewCosmosChain(testName string, chainConfig ibc.ChainConfig, numValidators int, numFullNodes int, log *zap.Logger) *CosmosChain {
+	if chainConfig.EncodingConfig == nil {
+		cfg := DefaultEncoding()
+		chainConfig.EncodingConfig = &cfg
+	}
 	return &CosmosChain{
 		testName:      testName,
 		cfg:           chainConfig,
@@ -689,7 +693,7 @@ func (c *CosmosChain) Height(ctx context.Context) (uint64, error) {
 // Acknowledgements implements ibc.Chain, returning all acknowledgments in block at height
 func (c *CosmosChain) Acknowledgements(ctx context.Context, height uint64) ([]ibc.PacketAcknowledgement, error) {
 	var acks []*chanTypes.MsgAcknowledgement
-	err := rangeBlockMessages(ctx, c.getFullNode().Client, height, func(msg types.Msg) bool {
+	err := rangeBlockMessages(ctx, c.cfg.EncodingConfig.InterfaceRegistry, c.getFullNode().Client, height, func(msg types.Msg) bool {
 		found, ok := msg.(*chanTypes.MsgAcknowledgement)
 		if ok {
 			acks = append(acks, found)
@@ -722,7 +726,7 @@ func (c *CosmosChain) Acknowledgements(ctx context.Context, height uint64) ([]ib
 // Timeouts implements ibc.Chain, returning all timeouts in block at height
 func (c *CosmosChain) Timeouts(ctx context.Context, height uint64) ([]ibc.PacketTimeout, error) {
 	var timeouts []*chanTypes.MsgTimeout
-	err := rangeBlockMessages(ctx, c.getFullNode().Client, height, func(msg types.Msg) bool {
+	err := rangeBlockMessages(ctx, c.cfg.EncodingConfig.InterfaceRegistry, c.getFullNode().Client, height, func(msg types.Msg) bool {
 		found, ok := msg.(*chanTypes.MsgTimeout)
 		if ok {
 			timeouts = append(timeouts, found)

--- a/chain/cosmos/query.go
+++ b/chain/cosmos/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	tmtypes "github.com/tendermint/tendermint/rpc/core/types"
 )
@@ -14,14 +15,14 @@ type blockClient interface {
 
 // rangeBlockMessages iterates through all a block's transactions and each transaction's messages yielding to f.
 // Return true from f to stop iteration.
-func rangeBlockMessages(ctx context.Context, client blockClient, height uint64, done func(sdk.Msg) bool) error {
+func rangeBlockMessages(ctx context.Context, interfaceRegistry codectypes.InterfaceRegistry, client blockClient, height uint64, done func(sdk.Msg) bool) error {
 	h := int64(height)
 	block, err := client.Block(ctx, &h)
 	if err != nil {
 		return fmt.Errorf("tendermint rpc get block: %w", err)
 	}
 	for _, txbz := range block.Block.Txs {
-		tx, err := decodeTX(txbz)
+		tx, err := decodeTX(interfaceRegistry, txbz)
 		if err != nil {
 			return fmt.Errorf("decode tendermint tx: %w", err)
 		}

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -1,6 +1,7 @@
 package ibc
 
 import (
+	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	"github.com/cosmos/cosmos-sdk/types"
 	ibcexported "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types"
 )
@@ -33,6 +34,8 @@ type ChainConfig struct {
 	ModifyGenesis func(ChainConfig, []byte) ([]byte, error)
 	// Override config parameters for files at filepath.
 	ConfigFileOverrides map[string]any
+	// Non-nil will override the encoding config, used for cosmos chains only.
+	EncodingConfig *simappparams.EncodingConfig
 }
 
 func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
@@ -86,6 +89,10 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 
 	if other.ConfigFileOverrides != nil {
 		c.ConfigFileOverrides = other.ConfigFileOverrides
+	}
+
+	if other.EncodingConfig != nil {
+		c.EncodingConfig = other.EncodingConfig
 	}
 
 	return c


### PR DESCRIPTION
Allow overriding the default `EncodingConfig` for custom codecs.

Make `cosmos.DefaultEncoding()` public so that default config can be fetched, enriched, then used as an override.

Example usage:
https://github.com/strangelove-ventures/ibctest/blob/3669846acdc03d09f1b9756823952e199fe13667/examples/osmosis/osmosis.go#L10-L17

https://github.com/strangelove-ventures/ibctest/blob/3669846acdc03d09f1b9756823952e199fe13667/examples/osmosis/cosmos_chain_gamm_pool_test.go#L34