### PR TITLE
InterchainLink create client/channel opts

### DIFF
--- a/conformance/flush.go
+++ b/conformance/flush.go
@@ -45,17 +45,17 @@ func TestRelayerFlushing(t *testing.T, cf ibctest.ChainFactory, rf ibctest.Relay
 			Chain2:  c1,
 			Relayer: r,
 
-			Path: pathName,
+			Path:              pathName,
+			CreateChannelOpts: ibc.DefaultChannelOpts(),
 		})
 
 	ctx := context.Background()
 	eRep := rep.RelayerExecReporter(t)
 
 	req.NoError(ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
-		TestName:          t.Name(),
-		Client:            client,
-		NetworkID:         network,
-		CreateChannelOpts: ibc.DefaultChannelOpts(),
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
 	}))
 	defer ic.Close()
 

--- a/examples/interchain_queries_test.go
+++ b/examples/interchain_queries_test.go
@@ -99,6 +99,12 @@ func TestInterchainQueries(t *testing.T) {
 			Chain2:  chain2,
 			Relayer: r,
 			Path:    pathName,
+			CreateChannelOpts: ibc.CreateChannelOptions{
+				SourcePortName: "interquery",
+				DestPortName:   "icqhost",
+				Order:          ibc.Unordered,
+				Version:        "icq-1",
+			},
 		})
 
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
@@ -107,12 +113,6 @@ func TestInterchainQueries(t *testing.T) {
 		NetworkID: network,
 
 		SkipPathCreation: false,
-		CreateChannelOpts: ibc.CreateChannelOptions{
-			SourcePortName: "interquery",
-			DestPortName:   "icqhost",
-			Order:          ibc.Unordered,
-			Version:        "icq-1",
-		},
 	}))
 
 	// Fund user accounts, so we can query balances and make assertions.

--- a/test_setup.go
+++ b/test_setup.go
@@ -80,7 +80,6 @@ func StartChainPairAndRelayer(
 		NetworkID:         networkID,
 		GitSha:            version.GitSha,
 		BlockDatabaseFile: blockSqlite,
-		CreateChannelOpts: ibc.DefaultChannelOpts(),
 	}); err != nil {
 		return errResponse(err)
 	}


### PR DESCRIPTION
Move `CreateClientOptions` and `CreateChannelOptions` to `InterchainLink` to allow differences for different paths.