### PR TITLE
Upgrade IBC test

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -690,13 +690,19 @@ func (tn *ChainNode) UpgradeProposal(ctx context.Context, keyName string, prop i
 	if err != nil {
 		return "", err
 	}
+	output := CosmosTx{}
+	err = json.Unmarshal([]byte(stdout), &output)
+	if err != nil {
+		return "", err
+	}
+	if output.Code != 0 {
+		return "", fmt.Errorf("failed to send upgrade proposal tx: %s", output.RawLog)
+	}
 	err = test.WaitForBlocks(ctx, 2, tn)
 	if err != nil {
 		return "", fmt.Errorf("wait for blocks: %w", err)
 	}
-	output := CosmosTx{}
-	err = json.Unmarshal([]byte(stdout), &output)
-	return output.TxHash, err
+	return output.TxHash, nil
 }
 
 func (tn *ChainNode) DumpContractState(ctx context.Context, contractAddress string, height int64) (*ibc.DumpContractStateResponse, error) {

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -618,7 +618,7 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 	}
 
 	if c.cfg.ModifyGenesis != nil {
-		genbz, err = c.cfg.ModifyGenesis(genbz)
+		genbz, err = c.cfg.ModifyGenesis(chainCfg, genbz)
 		if err != nil {
 			return err
 		}

--- a/cmd/ibctest/ibctest_test.go
+++ b/cmd/ibctest/ibctest_test.go
@@ -193,6 +193,8 @@ func getChainFactory(log *zap.Logger, chainSpecs []*ibctest.ChainSpec) (ibctest.
 func TestConformance(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
+
 	logger, err := extraFlags.Logger()
 	if err != nil {
 		t.Fatal(err)
@@ -226,7 +228,7 @@ func TestConformance(t *testing.T) {
 	}
 
 	// Begin test execution, which will spawn many parallel subtests.
-	conformance.Test(t, chainFactories, relayerFactories, reporter)
+	conformance.Test(t, ctx, chainFactories, relayerFactories, reporter)
 }
 
 // addFlags configures additional flags beyond the default testing flags.

--- a/conformance/flush.go
+++ b/conformance/flush.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRelayerFlushing(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory, rep *testreporter.Reporter) {
+func TestRelayerFlushing(t *testing.T, ctx context.Context, cf ibctest.ChainFactory, rf ibctest.RelayerFactory, rep *testreporter.Reporter) {
 	rep.TrackTest(t)
 
 	// FlushPackets will be exercised in a subtest,
@@ -48,7 +48,6 @@ func TestRelayerFlushing(t *testing.T, cf ibctest.ChainFactory, rf ibctest.Relay
 			Path: pathName,
 		})
 
-	ctx := context.Background()
 	eRep := rep.RelayerExecReporter(t)
 
 	req.NoError(ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{

--- a/conformance/relayersetup.go
+++ b/conformance/relayersetup.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TestRelayerSetup contains a series of subtests that configure a relayer step-by-step.
-func TestRelayerSetup(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory, rep *testreporter.Reporter) {
+func TestRelayerSetup(t *testing.T, ctx context.Context, cf ibctest.ChainFactory, rf ibctest.RelayerFactory, rep *testreporter.Reporter) {
 	rep.TrackTest(t)
 
 	client, network := ibctest.DockerSetup(t)
@@ -47,7 +47,6 @@ func TestRelayerSetup(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerF
 			Path: pathName,
 		})
 
-	ctx := context.Background()
 	eRep := rep.RelayerExecReporter(t)
 
 	req.NoError(ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -36,8 +36,10 @@ import (
 	"time"
 
 	transfertypes "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types"
+	"github.com/docker/docker/client"
 	"github.com/strangelove-ventures/ibctest"
 	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/internal/dockerutil"
 	"github.com/strangelove-ventures/ibctest/label"
 	"github.com/strangelove-ventures/ibctest/relayer"
 	"github.com/strangelove-ventures/ibctest/test"
@@ -52,12 +54,17 @@ const (
 	pollHeightMax  = uint64(50)
 )
 
+type TxCache struct {
+	Src []ibc.Tx
+	Dst []ibc.Tx
+}
+
 type RelayerTestCase struct {
 	Config RelayerTestCaseConfig
 	// user on source chain
 	Users []*ibc.Wallet
 	// temp storage in between test phases
-	TxCache []ibc.Tx
+	TxCache TxCache
 }
 
 type RelayerTestCaseConfig struct {
@@ -152,37 +159,50 @@ func sendIBCTransfersFromBothChainsWithTimeout(
 		Amount:  testCoinAmount,
 	}
 
-	var (
-		eg    errgroup.Group
-		srcTx ibc.Tx
-		dstTx ibc.Tx
-	)
+	var eg errgroup.Group
+	srcTxs := make([]ibc.Tx, len(channels))
+	dstTxs := make([]ibc.Tx, len(channels))
 
-	eg.Go(func() error {
-		var err error
-		srcChannelID := channels[0].ChannelID
-		srcTx, err = srcChain.SendIBCTransfer(ctx, srcChannelID, srcUser.KeyName, testCoinSrcToDst, timeout)
-		if err != nil {
-			return fmt.Errorf("failed to send ibc transfer from source: %w", err)
+	eg.Go(func() (err error) {
+		for i, channel := range channels {
+			srcChannelID := channel.ChannelID
+			srcTxs[i], err = srcChain.SendIBCTransfer(ctx, srcChannelID, srcUser.KeyName, testCoinSrcToDst, timeout)
+			if err != nil {
+				return fmt.Errorf("failed to send ibc transfer from source: %w", err)
+			}
+			if err := test.WaitForBlocks(ctx, 1, srcChain); err != nil {
+				return err
+			}
 		}
 		return nil
 	})
 
-	eg.Go(func() error {
-		var err error
-		dstChannelID := channels[0].Counterparty.ChannelID
-		dstTx, err = dstChain.SendIBCTransfer(ctx, dstChannelID, dstUser.KeyName, testCoinDstToSrc, timeout)
-		if err != nil {
-			return fmt.Errorf("failed to send ibc transfer from destination: %w", err)
+	eg.Go(func() (err error) {
+		for i, channel := range channels {
+			dstChannelID := channel.Counterparty.ChannelID
+			dstTxs[i], err = dstChain.SendIBCTransfer(ctx, dstChannelID, dstUser.KeyName, testCoinDstToSrc, timeout)
+			if err != nil {
+				return fmt.Errorf("failed to send ibc transfer from destination: %w", err)
+			}
+			if err := test.WaitForBlocks(ctx, 1, dstChain); err != nil {
+				return err
+			}
 		}
 		return nil
 	})
 
 	require.NoError(t, eg.Wait())
-	require.NoError(t, srcTx.Validate(), "source ibc transfer tx is invalid")
-	require.NoError(t, dstTx.Validate(), "destination ibc transfer tx is invalid")
+	for _, srcTx := range srcTxs {
+		require.NoError(t, srcTx.Validate(), "source ibc transfer tx is invalid")
+	}
+	for _, dstTx := range dstTxs {
+		require.NoError(t, dstTx.Validate(), "destination ibc transfer tx is invalid")
+	}
 
-	testCase.TxCache = []ibc.Tx{srcTx, dstTx}
+	testCase.TxCache = TxCache{
+		Src: srcTxs,
+		Dst: dstTxs,
+	}
 }
 
 // Test is the stable API exposed by the conformance package.
@@ -192,7 +212,7 @@ func sendIBCTransfersFromBothChainsWithTimeout(
 // so that it can properly group subtests in a single invocation.
 // If the subtest configuration does not meet your needs,
 // you can directly call one of the other exported Test functions, such as TestChainPair.
-func Test(t *testing.T, cfs []ibctest.ChainFactory, rfs []ibctest.RelayerFactory, rep *testreporter.Reporter) {
+func Test(t *testing.T, ctx context.Context, cfs []ibctest.ChainFactory, rfs []ibctest.RelayerFactory, rep *testreporter.Reporter) {
 	// Validate chain factory counts up front.
 	counts := make(map[int]bool)
 	for _, cf := range cfs {
@@ -226,21 +246,29 @@ func Test(t *testing.T, cfs []ibctest.ChainFactory, rfs []ibctest.RelayerFactory
 								rep.TrackTest(t)
 								rep.TrackParallel(t)
 
-								TestRelayerSetup(t, cf, rf, rep)
+								TestRelayerSetup(t, ctx, cf, rf, rep)
 							})
 
 							t.Run("conformance", func(t *testing.T) {
 								rep.TrackTest(t)
 								rep.TrackParallel(t)
 
-								TestChainPair(t, cf, rf, rep)
+								chains, err := cf.Chains(t.Name())
+								require.NoError(t, err, "failed to get chains")
+
+								if len(chains) != 2 {
+									panic(fmt.Errorf("expected 2 chains, got %d", len(chains)))
+								}
+
+								client, network := ibctest.DockerSetup(t)
+								TestChainPair(t, ctx, client, network, chains[0], chains[1], rf, rep, nil)
 							})
 
 							t.Run("flushing", func(t *testing.T) {
 								rep.TrackTest(t)
 								rep.TrackParallel(t)
 
-								TestRelayerFlushing(t, cf, rf, rep)
+								TestRelayerFlushing(t, ctx, cf, rf, rep)
 							})
 						})
 					}
@@ -258,26 +286,27 @@ func Test(t *testing.T, cfs []ibctest.ChainFactory, rfs []ibctest.RelayerFactory
 // 2. Proper handling of no timeout from A -> B and B -> A.
 // 3. Proper handling of height timeout from A -> B and B -> A.
 // 4. Proper handling of timestamp timeout from A -> B and B -> A.
-func TestChainPair(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory, rep *testreporter.Reporter) {
-	client, network := ibctest.DockerSetup(t)
-
+// If a non-nil relayerImpl is passed, it is assumed that the chains are already started.
+func TestChainPair(
+	t *testing.T,
+	ctx context.Context,
+	client *client.Client,
+	network string,
+	srcChain, dstChain ibc.Chain,
+	rf ibctest.RelayerFactory,
+	rep *testreporter.Reporter,
+	relayerImpl ibc.Relayer,
+	pathNames ...string,
+) {
 	req := require.New(rep.TestifyT(t))
-	chains, err := cf.Chains(t.Name())
-	req.NoError(err, "failed to get chains")
-
-	if len(chains) != 2 {
-		panic(fmt.Errorf("expected 2 chains, got %d", len(chains)))
-	}
-
-	srcChain := chains[0]
-	dstChain := chains[1]
 
 	var (
 		preRelayerStartFuncs []func([]ibc.ChannelOutput)
 		testCases            []*RelayerTestCase
-
-		ctx = context.Background()
+		err                  error
 	)
+
+	randomSuffix := dockerutil.RandLowerCaseLetterString(4)
 
 	for _, testCaseConfig := range relayerTestCaseConfigs {
 		testCase := RelayerTestCase{
@@ -292,30 +321,46 @@ func TestChainPair(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFact
 		}
 		preRelayerStartFunc := func(channels []ibc.ChannelOutput) {
 			// fund a user wallet on both chains, save on test case
-			testCase.Users = ibctest.GetAndFundTestUsers(t, ctx, strings.ReplaceAll(testCase.Config.Name, " ", "-"), userFaucetFund, srcChain, dstChain)
+			testCase.Users = ibctest.GetAndFundTestUsers(t, ctx, strings.ReplaceAll(testCase.Config.Name, " ", "-")+"-"+randomSuffix, userFaucetFund, srcChain, dstChain)
 			// run test specific pre relayer start action
 			testCase.Config.PreRelayerStart(ctx, t, &testCase, srcChain, dstChain, channels)
 		}
 		preRelayerStartFuncs = append(preRelayerStartFuncs, preRelayerStartFunc)
 	}
 
-	// startup both chains and relayer
-	// creates wallets in the relayer for src and dst chain
-	// funds relayer src and dst wallets on respective chain in genesis
-	// creates a faucet account on the both chains (separate fullnode)
-	// funds faucet accounts in genesis
-	_, channels, err := ibctest.StartChainPairAndRelayer(t, ctx, rep, client, network, srcChain, dstChain, rf, preRelayerStartFuncs)
-	req.NoError(err, "failed to StartChainPairAndRelayer")
-
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(testCase.Config.Name, func(t *testing.T) {
-			rep.TrackTest(t, testCase.Config.TestLabels...)
-			requireCapabilities(t, rep, rf, testCase.Config.RequiredRelayerCapabilities...)
-			rep.TrackParallel(t)
-			testCase.Config.Test(ctx, t, testCase, rep, srcChain, dstChain, channels)
-		})
+	if relayerImpl == nil {
+		// startup both chains.
+		// creates wallets in the relayer for src and dst chain.
+		// funds relayer src and dst wallets on respective chain in genesis.
+		// creates a faucet account on the both chains (separate fullnode).
+		// funds faucet accounts in genesis.
+		relayerImpl, err = ibctest.StartChainPair(t, ctx, rep, client, network, srcChain, dstChain, rf, preRelayerStartFuncs)
+		req.NoError(err, "failed to StartChainPair")
 	}
+
+	// execute the pre relayer start functions, then start the relayer.
+	channels, err := ibctest.StopStartRelayerWithPreStartFuncs(
+		t,
+		ctx,
+		srcChain.Config().ChainID,
+		relayerImpl,
+		rep.RelayerExecReporter(t),
+		preRelayerStartFuncs,
+		pathNames...,
+	)
+	req.NoError(err, "failed to StopStartRelayerWithPreStartFuncs")
+
+	t.Run("post_relayer_start", func(t *testing.T) {
+		for _, testCase := range testCases {
+			testCase := testCase
+			t.Run(testCase.Config.Name, func(t *testing.T) {
+				rep.TrackTest(t, testCase.Config.TestLabels...)
+				requireCapabilities(t, rep, rf, testCase.Config.RequiredRelayerCapabilities...)
+				rep.TrackParallel(t)
+				testCase.Config.Test(ctx, t, testCase, rep, srcChain, dstChain, channels)
+			})
+		}
+	})
 }
 
 // PreRelayerStart methods for the RelayerTestCases
@@ -364,66 +409,64 @@ func testPacketRelaySuccess(
 	dstChainCfg := dstChain.Config()
 
 	// [BEGIN] assert on source to destination transfer
-	t.Logf("Asserting %s to %s transfer", srcChainCfg.ChainID, dstChainCfg.ChainID)
-	// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
-	srcInitialBalance := userFaucetFund
-	dstInitialBalance := int64(0)
+	for i, srcTx := range testCase.TxCache.Src {
+		t.Logf("Asserting %s to %s transfer", srcChainCfg.ChainID, dstChainCfg.ChainID)
+		// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
+		srcInitialBalance := userFaucetFund
+		dstInitialBalance := int64(0)
 
-	// fetch src ibc transfer tx
-	srcTx := testCase.TxCache[0]
+		srcAck, err := test.PollForAck(ctx, srcChain, srcTx.Height, srcTx.Height+pollHeightMax, srcTx.Packet)
+		req.NoError(err, "failed to get acknowledgement on source chain")
+		req.NoError(srcAck.Validate(), "invalid acknowledgement on source chain")
 
-	srcAck, err := test.PollForAck(ctx, srcChain, srcTx.Height, srcTx.Height+pollHeightMax, srcTx.Packet)
-	req.NoError(err, "failed to get acknowledgement on source chain")
-	req.NoError(srcAck.Validate(), "invalid acknowledgement on source chain")
+		// get ibc denom for src denom on dst chain
+		srcDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom(channels[i].Counterparty.PortID, channels[i].Counterparty.ChannelID, srcDenom))
+		dstIbcDenom := srcDenomTrace.IBCDenom()
 
-	// get ibc denom for src denom on dst chain
-	srcDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom(channels[0].Counterparty.PortID, channels[0].Counterparty.ChannelID, srcDenom))
-	dstIbcDenom := srcDenomTrace.IBCDenom()
+		srcFinalBalance, err := srcChain.GetBalance(ctx, srcUser.Bech32Address(srcChainCfg.Bech32Prefix), srcDenom)
+		req.NoError(err, "failed to get balance from source chain")
 
-	srcFinalBalance, err := srcChain.GetBalance(ctx, srcUser.Bech32Address(srcChainCfg.Bech32Prefix), srcDenom)
-	req.NoError(err, "failed to get balance from source chain")
+		dstFinalBalance, err := dstChain.GetBalance(ctx, srcUser.Bech32Address(dstChainCfg.Bech32Prefix), dstIbcDenom)
+		req.NoError(err, "failed to get balance from dest chain")
 
-	dstFinalBalance, err := dstChain.GetBalance(ctx, srcUser.Bech32Address(dstChainCfg.Bech32Prefix), dstIbcDenom)
-	req.NoError(err, "failed to get balance from dest chain")
+		totalFees := srcChain.GetGasFeesInNativeDenom(srcTx.GasSpent)
+		expectedDifference := testCoinAmount + totalFees
 
-	totalFees := srcChain.GetGasFeesInNativeDenom(srcTx.GasSpent)
-	expectedDifference := testCoinAmount + totalFees
-
-	req.Equal(srcInitialBalance-expectedDifference, srcFinalBalance)
-	req.Equal(dstInitialBalance+testCoinAmount, dstFinalBalance)
+		req.Equal(srcInitialBalance-expectedDifference, srcFinalBalance)
+		req.Equal(dstInitialBalance+testCoinAmount, dstFinalBalance)
+	}
 
 	// [END] assert on source to destination transfer
 
 	// [BEGIN] assert on destination to source transfer
-	t.Logf("Asserting %s to %s transfer", dstChainCfg.ChainID, srcChainCfg.ChainID)
-	dstUser := testCase.Users[1]
-	dstDenom := dstChainCfg.Denom
-	// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
-	srcInitialBalance = int64(0)
-	dstInitialBalance = userFaucetFund
-	// fetch src ibc transfer tx
-	dstTx := testCase.TxCache[1]
+	for i, dstTx := range testCase.TxCache.Dst {
+		t.Logf("Asserting %s to %s transfer", dstChainCfg.ChainID, srcChainCfg.ChainID)
+		dstUser := testCase.Users[1]
+		dstDenom := dstChainCfg.Denom
+		// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
+		srcInitialBalance := int64(0)
+		dstInitialBalance := userFaucetFund
 
-	dstAck, err := test.PollForAck(ctx, dstChain, dstTx.Height, dstTx.Height+pollHeightMax, dstTx.Packet)
-	req.NoError(err, "failed to get acknowledgement on destination chain")
-	req.NoError(dstAck.Validate(), "invalid acknowledgement on destination chain")
+		dstAck, err := test.PollForAck(ctx, dstChain, dstTx.Height, dstTx.Height+pollHeightMax, dstTx.Packet)
+		req.NoError(err, "failed to get acknowledgement on destination chain")
+		req.NoError(dstAck.Validate(), "invalid acknowledgement on destination chain")
 
-	// get ibc denom for dst denom on src chain
-	dstDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom(channels[0].PortID, channels[0].ChannelID, dstDenom))
-	srcIbcDenom := dstDenomTrace.IBCDenom()
+		// get ibc denom for dst denom on src chain
+		dstDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom(channels[i].PortID, channels[i].ChannelID, dstDenom))
+		srcIbcDenom := dstDenomTrace.IBCDenom()
 
-	srcFinalBalance, err = srcChain.GetBalance(ctx, dstUser.Bech32Address(srcChainCfg.Bech32Prefix), srcIbcDenom)
-	req.NoError(err, "failed to get balance from source chain")
+		srcFinalBalance, err := srcChain.GetBalance(ctx, dstUser.Bech32Address(srcChainCfg.Bech32Prefix), srcIbcDenom)
+		req.NoError(err, "failed to get balance from source chain")
 
-	dstFinalBalance, err = dstChain.GetBalance(ctx, dstUser.Bech32Address(dstChainCfg.Bech32Prefix), dstDenom)
-	req.NoError(err, "failed to get balance from dest chain")
+		dstFinalBalance, err := dstChain.GetBalance(ctx, dstUser.Bech32Address(dstChainCfg.Bech32Prefix), dstDenom)
+		req.NoError(err, "failed to get balance from dest chain")
 
-	totalFees = dstChain.GetGasFeesInNativeDenom(dstTx.GasSpent)
-	expectedDifference = testCoinAmount + totalFees
+		totalFees := dstChain.GetGasFeesInNativeDenom(dstTx.GasSpent)
+		expectedDifference := testCoinAmount + totalFees
 
-	req.Equal(srcInitialBalance+testCoinAmount, srcFinalBalance)
-	req.Equal(dstInitialBalance-expectedDifference, dstFinalBalance)
-
+		req.Equal(srcInitialBalance+testCoinAmount, srcFinalBalance)
+		req.Equal(dstInitialBalance-expectedDifference, dstFinalBalance)
+	}
 	//[END] assert on destination to source transfer
 }
 
@@ -448,61 +491,60 @@ func testPacketRelayFail(
 	dstDenom := dstChainCfg.Denom
 
 	// [BEGIN] assert on source to destination transfer
-	// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
-	srcInitialBalance := userFaucetFund
-	dstInitialBalance := int64(0)
+	for i, srcTx := range testCase.TxCache.Src {
+		// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
+		srcInitialBalance := userFaucetFund
+		dstInitialBalance := int64(0)
 
-	// fetch src ibc transfer tx
-	srcTx := testCase.TxCache[0]
+		timeout, err := test.PollForTimeout(ctx, srcChain, srcTx.Height, srcTx.Height+pollHeightMax, srcTx.Packet)
+		req.NoError(err, "failed to get timeout packet on source chain")
+		req.NoError(timeout.Validate(), "invalid timeout packet on source chain")
 
-	timeout, err := test.PollForTimeout(ctx, srcChain, srcTx.Height, srcTx.Height+pollHeightMax, srcTx.Packet)
-	req.NoError(err, "failed to get timeout packet on source chain")
-	req.NoError(timeout.Validate(), "invalid timeout packet on source chain")
+		// Even though we poll for the timeout, there may be timing issues where balances are not fully reconciled yet.
+		// So we have a small buffer here.
+		require.NoError(t, test.WaitForBlocks(ctx, 2, srcChain, dstChain))
 
-	// Even though we poll for the timeout, there may be timing issues where balances are not fully reconciled yet.
-	// So we have a small buffer here.
-	require.NoError(t, test.WaitForBlocks(ctx, 2, srcChain, dstChain))
+		// get ibc denom for src denom on dst chain
+		srcDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom(channels[i].Counterparty.PortID, channels[i].Counterparty.ChannelID, srcDenom))
+		dstIbcDenom := srcDenomTrace.IBCDenom()
 
-	// get ibc denom for src denom on dst chain
-	srcDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom(channels[0].Counterparty.PortID, channels[0].Counterparty.ChannelID, srcDenom))
-	dstIbcDenom := srcDenomTrace.IBCDenom()
+		srcFinalBalance, err := srcChain.GetBalance(ctx, srcUser.Bech32Address(srcChainCfg.Bech32Prefix), srcDenom)
+		req.NoError(err, "failed to get balance from source chain")
 
-	srcFinalBalance, err := srcChain.GetBalance(ctx, srcUser.Bech32Address(srcChainCfg.Bech32Prefix), srcDenom)
-	req.NoError(err, "failed to get balance from source chain")
+		dstFinalBalance, err := dstChain.GetBalance(ctx, srcUser.Bech32Address(dstChainCfg.Bech32Prefix), dstIbcDenom)
+		req.NoError(err, "failed to get balance from destination chain")
 
-	dstFinalBalance, err := dstChain.GetBalance(ctx, srcUser.Bech32Address(dstChainCfg.Bech32Prefix), dstIbcDenom)
-	req.NoError(err, "failed to get balance from destination chain")
+		totalFees := srcChain.GetGasFeesInNativeDenom(srcTx.GasSpent)
 
-	totalFees := srcChain.GetGasFeesInNativeDenom(srcTx.GasSpent)
-
-	req.Equal(srcInitialBalance-totalFees, srcFinalBalance)
-	req.Equal(dstInitialBalance, dstFinalBalance)
+		req.Equal(srcInitialBalance-totalFees, srcFinalBalance)
+		req.Equal(dstInitialBalance, dstFinalBalance)
+	}
 	// [END] assert on source to destination transfer
 
 	// [BEGIN] assert on destination to source transfer
-	// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
-	srcInitialBalance = int64(0)
-	dstInitialBalance = userFaucetFund
-	// fetch src ibc transfer tx
-	dstTx := testCase.TxCache[1]
+	for i, dstTx := range testCase.TxCache.Dst {
+		// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
+		srcInitialBalance := int64(0)
+		dstInitialBalance := userFaucetFund
 
-	timeout, err = test.PollForTimeout(ctx, dstChain, dstTx.Height, dstTx.Height+pollHeightMax, dstTx.Packet)
-	req.NoError(err, "failed to get timeout packet on destination chain")
-	req.NoError(timeout.Validate(), "invalid timeout packet on destination chain")
+		timeout, err := test.PollForTimeout(ctx, dstChain, dstTx.Height, dstTx.Height+pollHeightMax, dstTx.Packet)
+		req.NoError(err, "failed to get timeout packet on destination chain")
+		req.NoError(timeout.Validate(), "invalid timeout packet on destination chain")
 
-	// get ibc denom for dst denom on src chain
-	dstDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom(channels[0].PortID, channels[0].ChannelID, dstDenom))
-	srcIbcDenom := dstDenomTrace.IBCDenom()
+		// get ibc denom for dst denom on src chain
+		dstDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom(channels[i].PortID, channels[i].ChannelID, dstDenom))
+		srcIbcDenom := dstDenomTrace.IBCDenom()
 
-	srcFinalBalance, err = srcChain.GetBalance(ctx, dstUser.Bech32Address(srcChainCfg.Bech32Prefix), srcIbcDenom)
-	req.NoError(err, "failed to get balance from source chain")
+		srcFinalBalance, err := srcChain.GetBalance(ctx, dstUser.Bech32Address(srcChainCfg.Bech32Prefix), srcIbcDenom)
+		req.NoError(err, "failed to get balance from source chain")
 
-	dstFinalBalance, err = dstChain.GetBalance(ctx, dstUser.Bech32Address(dstChainCfg.Bech32Prefix), dstDenom)
-	req.NoError(err, "failed to get balance from destination chain")
+		dstFinalBalance, err := dstChain.GetBalance(ctx, dstUser.Bech32Address(dstChainCfg.Bech32Prefix), dstDenom)
+		req.NoError(err, "failed to get balance from destination chain")
 
-	totalFees = dstChain.GetGasFeesInNativeDenom(dstTx.GasSpent)
+		totalFees := dstChain.GetGasFeesInNativeDenom(dstTx.GasSpent)
 
-	req.Equal(srcInitialBalance, srcFinalBalance)
-	req.Equal(dstInitialBalance-totalFees, dstFinalBalance)
+		req.Equal(srcInitialBalance, srcFinalBalance)
+		req.Equal(dstInitialBalance-totalFees, dstFinalBalance)
+	}
 	// [END] assert on destination to source transfer
 }

--- a/conformance/test.go
+++ b/conformance/test.go
@@ -254,10 +254,8 @@ func Test(t *testing.T, ctx context.Context, cfs []ibctest.ChainFactory, rfs []i
 								rep.TrackParallel(t)
 
 								chains, err := cf.Chains(t.Name())
-								require.NoError(t, err, "failed to get chains")
-
-								if len(chains) != 2 {
-									panic(fmt.Errorf("expected 2 chains, got %d", len(chains)))
+								if err != nil {
+									panic(fmt.Errorf("failed to get chains: %v", err))
 								}
 
 								client, network := ibctest.DockerSetup(t)

--- a/examples/cosmos_chain_upgrade_ibc_test.go
+++ b/examples/cosmos_chain_upgrade_ibc_test.go
@@ -16,10 +16,10 @@ import (
 )
 
 func TestJunoUpgradeIBC(t *testing.T) {
-	CosmosChainUpgradeIBCTest(t, "juno", "v6.0.0", "v7.0.0")
+	CosmosChainUpgradeIBCTest(t, "juno", "v6.0.0", "v8.0.0", "multiverse")
 }
 
-func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeVersion string) {
+func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeVersion string, upgradeName string) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -32,7 +32,7 @@ func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeV
 			ChainName: chainName,
 			Version:   initialVersion,
 			ChainConfig: ibc.ChainConfig{
-				ModifyGenesis: modifyGenesisVotingPeriod(votingPeriod),
+				ModifyGenesis: modifyGenesisShortProposals(votingPeriod, maxDepositPeriod),
 			},
 		},
 		{
@@ -103,7 +103,7 @@ func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeV
 	proposal := ibc.SoftwareUpgradeProposal{
 		Deposit:     "500000000" + chain.Config().Denom,
 		Title:       "Chain Upgrade 1",
-		Name:        "chain-upgrade",
+		Name:        upgradeName,
 		Description: "First chain software upgrade",
 		Height:      haltHeight,
 	}
@@ -120,7 +120,7 @@ func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeV
 	height, err = chain.Height(ctx)
 	require.NoError(t, err, "error fetching height before upgrade")
 
-	timeoutCtx, timeoutCtxCancel := context.WithTimeout(ctx, time.Minute*2)
+	timeoutCtx, timeoutCtxCancel := context.WithTimeout(ctx, time.Second*45)
 	defer timeoutCtxCancel()
 
 	_ = test.WaitForBlocks(timeoutCtx, int(haltHeight-height)+1, chain)

--- a/examples/cosmos_chain_upgrade_ibc_test.go
+++ b/examples/cosmos_chain_upgrade_ibc_test.go
@@ -1,0 +1,154 @@
+package ibctest_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/chain/cosmos"
+	"github.com/strangelove-ventures/ibctest/conformance"
+	"github.com/strangelove-ventures/ibctest/ibc"
+	"github.com/strangelove-ventures/ibctest/test"
+	"github.com/strangelove-ventures/ibctest/testreporter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestJunoUpgradeIBC(t *testing.T) {
+	CosmosChainUpgradeIBCTest(t, "juno", "v6.0.0", "v7.0.0")
+}
+
+func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeVersion string) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Parallel()
+
+	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
+		{
+			Name:      chainName,
+			ChainName: chainName,
+			Version:   initialVersion,
+			ChainConfig: ibc.ChainConfig{
+				ModifyGenesis: modifyGenesisVotingPeriod(votingPeriod),
+			},
+		},
+		{
+			Name:      "gaia",
+			ChainName: "gaia",
+			Version:   "v7.0.3",
+		},
+	})
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+
+	client, network := ibctest.DockerSetup(t)
+
+	chain, counterpartyChain := chains[0].(*cosmos.CosmosChain), chains[1].(*cosmos.CosmosChain)
+
+	const (
+		path        = "ibc-upgrade-test-path"
+		relayerName = "relayer"
+	)
+
+	// Get a relayer instance
+	rf := ibctest.NewBuiltinRelayerFactory(
+		ibc.CosmosRly,
+		zaptest.NewLogger(t),
+	)
+
+	r := rf.Build(t, client, network)
+
+	ic := ibctest.NewInterchain().
+		AddChain(chain).
+		AddChain(counterpartyChain).
+		AddRelayer(r, relayerName).
+		AddLink(ibctest.InterchainLink{
+			Chain1:  chain,
+			Chain2:  counterpartyChain,
+			Relayer: r,
+			Path:    path,
+		})
+
+	ctx := context.Background()
+
+	rep := testreporter.NewNopReporter()
+
+	require.NoError(t, ic.Build(ctx, rep.RelayerExecReporter(t), ibctest.InterchainBuildOptions{
+		TestName:          t.Name(),
+		Client:            client,
+		NetworkID:         network,
+		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
+		SkipPathCreation:  false,
+	}))
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
+
+	const userFunds = int64(10_000_000_000)
+	users := ibctest.GetAndFundTestUsers(t, ctx, t.Name(), userFunds, chain)
+	chainUser := users[0]
+
+	// Test IBC conformance before chain upgrade.
+	conformance.TestChainPair(t, ctx, client, network, chain, counterpartyChain, rf, rep, r, path)
+
+	height, err := chain.Height(ctx)
+	require.NoError(t, err, "error fetching height before submit upgrade proposal")
+
+	haltHeight := height + haltHeightDelta
+
+	proposal := ibc.SoftwareUpgradeProposal{
+		Deposit:     "500000000" + chain.Config().Denom,
+		Title:       "Chain Upgrade 1",
+		Name:        "chain-upgrade",
+		Description: "First chain software upgrade",
+		Height:      haltHeight,
+	}
+
+	upgradeTx, err := chain.UpgradeProposal(ctx, chainUser.KeyName, proposal)
+	require.NoError(t, err, "error submitting software upgrade proposal tx")
+
+	err = test.WaitForBlocks(ctx, 2, chain)
+	require.NoError(t, err)
+
+	err = chain.VoteOnProposalAllValidators(ctx, upgradeTx.ProposalID, ibc.ProposalVoteYes)
+	require.NoError(t, err, "failed to submit votes")
+
+	height, err = chain.Height(ctx)
+	require.NoError(t, err, "error fetching height before upgrade")
+
+	timeoutCtx, timeoutCtxCancel := context.WithTimeout(ctx, time.Minute*2)
+	defer timeoutCtxCancel()
+
+	_ = test.WaitForBlocks(timeoutCtx, int(haltHeight-height)+1, chain)
+
+	height, err = chain.Height(ctx)
+	require.NoError(t, err, "error fetching height after chain should have halted")
+
+	require.Equal(t, haltHeight, height, "height is not equal to halt height")
+
+	err = chain.StopAllNodes(ctx)
+	require.NoError(t, err, "error stopping node(s)")
+
+	chain.UpgradeVersion(ctx, client, upgradeVersion)
+
+	err = chain.StartAllNodes(ctx)
+	require.NoError(t, err, "error starting upgraded node(s)")
+
+	timeoutCtx, timeoutCtxCancel = context.WithTimeout(ctx, time.Second*45)
+	defer timeoutCtxCancel()
+
+	err = test.WaitForBlocks(timeoutCtx, int(blocksAfterUpgrade), chain)
+	require.NoError(t, err, "chain did not produce blocks after upgrade")
+
+	height, err = chain.Height(ctx)
+	require.NoError(t, err, "error fetching height after upgrade")
+
+	require.GreaterOrEqual(t, height, haltHeight+blocksAfterUpgrade, "height did not increment enough after upgrade")
+
+	// Test IBC conformance before chain upgrade.
+	conformance.TestChainPair(t, ctx, client, network, chain, counterpartyChain, rf, rep, r, path)
+}

--- a/examples/cosmos_chain_upgrade_test.go
+++ b/examples/cosmos_chain_upgrade_test.go
@@ -17,17 +17,17 @@ import (
 )
 
 const (
-	haltHeightDelta    = uint64(30) // will propose upgrade this many blocks in the future
+	haltHeightDelta    = uint64(10) // will propose upgrade this many blocks in the future
 	blocksAfterUpgrade = uint64(10)
 	votingPeriod       = "10s"
 	maxDepositPeriod   = "10s"
 )
 
 func TestJunoUpgrade(t *testing.T) {
-	CosmosChainUpgradeTest(t, "juno", "v6.0.0", "v7.0.0")
+	CosmosChainUpgradeTest(t, "juno", "v6.0.0", "v8.0.0", "multiverse")
 }
 
-func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeVersion string) {
+func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeVersion string, upgradeName string) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -40,7 +40,7 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeVers
 			ChainName: chainName,
 			Version:   initialVersion,
 			ChainConfig: ibc.ChainConfig{
-				ModifyGenesis: modifyGenesisVotingPeriod(votingPeriod),
+				ModifyGenesis: modifyGenesisShortProposals(votingPeriod, maxDepositPeriod),
 			},
 		},
 	})
@@ -79,7 +79,7 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeVers
 	proposal := ibc.SoftwareUpgradeProposal{
 		Deposit:     "500000000" + chain.Config().Denom,
 		Title:       "Chain Upgrade 1",
-		Name:        "chain-upgrade",
+		Name:        upgradeName,
 		Description: "First chain software upgrade",
 		Height:      haltHeight,
 	}
@@ -93,7 +93,7 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeVers
 	err = chain.VoteOnProposalAllValidators(ctx, upgradeTx.ProposalID, ibc.ProposalVoteYes)
 	require.NoError(t, err, "failed to submit votes")
 
-	timeoutCtx, timeoutCtxCancel := context.WithTimeout(ctx, time.Minute*2)
+	timeoutCtx, timeoutCtxCancel := context.WithTimeout(ctx, time.Second*45)
 	defer timeoutCtxCancel()
 
 	height, err = chain.Height(ctx)
@@ -126,8 +126,8 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeVers
 	require.GreaterOrEqual(t, height, haltHeight+blocksAfterUpgrade, "height did not increment enough after upgrade")
 }
 
-func modifyGenesisVotingPeriod(votingPeriod string) func([]byte) ([]byte, error) {
-	return func(genbz []byte) ([]byte, error) {
+func modifyGenesisShortProposals(votingPeriod string, maxDepositPeriod string) func(ibc.ChainConfig, []byte) ([]byte, error) {
+	return func(chainConfig ibc.ChainConfig, genbz []byte) ([]byte, error) {
 		g := make(map[string]interface{})
 		if err := json.Unmarshal(genbz, &g); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal genesis file: %w", err)
@@ -136,6 +136,9 @@ func modifyGenesisVotingPeriod(votingPeriod string) func([]byte) ([]byte, error)
 			return nil, fmt.Errorf("failed to set voting period in genesis json: %w", err)
 		}
 		if err := dyno.Set(g, maxDepositPeriod, "app_state", "gov", "deposit_params", "max_deposit_period"); err != nil {
+			return nil, fmt.Errorf("failed to set voting period in genesis json: %w", err)
+		}
+		if err := dyno.Set(g, chainConfig.Denom, "app_state", "gov", "deposit_params", "min_deposit", 0, "denom"); err != nil {
 			return nil, fmt.Errorf("failed to set voting period in genesis json: %w", err)
 		}
 		out, err := json.Marshal(g)

--- a/examples/interchain_queries_test.go
+++ b/examples/interchain_queries_test.go
@@ -114,6 +114,9 @@ func TestInterchainQueries(t *testing.T) {
 			Version:        "icq-1",
 		},
 	}))
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
 
 	// Fund user accounts, so we can query balances and make assertions.
 	const userFunds = int64(10_000_000_000)

--- a/examples/interchain_queries_test.go
+++ b/examples/interchain_queries_test.go
@@ -83,7 +83,7 @@ func TestInterchainQueries(t *testing.T) {
 	r := ibctest.NewBuiltinRelayerFactory(
 		ibc.CosmosRly,
 		zaptest.NewLogger(t),
-		relayer.RelayerOptionExtraStartFlags{Flags: []string{"-p", "events", "-b", "100"}},
+		relayer.StartupFlags("-p", "events", "-b", "100"),
 	).Build(t, client, network)
 
 	// Build the network; spin up the chains and configure the relayer
@@ -217,8 +217,8 @@ type icqResults struct {
 	} `json:"response"`
 }
 
-func modifyGenesisAllowICQQueries(allowQueries []string) func([]byte) ([]byte, error) {
-	return func(genbz []byte) ([]byte, error) {
+func modifyGenesisAllowICQQueries(allowQueries []string) func(ibc.ChainConfig, []byte) ([]byte, error) {
+	return func(chainConfig ibc.ChainConfig, genbz []byte) ([]byte, error) {
 		g := make(map[string]interface{})
 		if err := json.Unmarshal(genbz, &g); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal genesis file: %w", err)

--- a/examples/packet_forward_test.go
+++ b/examples/packet_forward_test.go
@@ -69,6 +69,9 @@ func TestPacketForwardMiddleware(t *testing.T) {
 
 		SkipPathCreation: false,
 	}))
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
 
 	const userFunds = int64(10_000_000_000)
 	users := ibctest.GetAndFundTestUsers(t, ctx, t.Name(), userFunds, osmosis, gaia, juno)

--- a/examples/state_sync_test.go
+++ b/examples/state_sync_test.go
@@ -77,6 +77,9 @@ func CosmosChainStateSyncTest(t *testing.T, chainName, version string) {
 		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
 		SkipPathCreation:  true,
 	}))
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
 
 	// Wait for blocks so that nodes have a few state sync snapshot available
 	require.NoError(t, test.WaitForBlocks(ctx, stateSyncSnapshotInterval*2, chain))

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -30,7 +30,7 @@ type ChainConfig struct {
 	// Do not use docker host mount.
 	NoHostMount bool
 	// When provided, genesis file contents will be altered before sharing for genesis.
-	ModifyGenesis func([]byte) ([]byte, error)
+	ModifyGenesis func(ChainConfig, []byte) ([]byte, error)
 	// Override config parameters for files at filepath.
 	ConfigFileOverrides map[string]any
 }


### PR DESCRIPTION
Tests IBC conformance on both sides of an upgrade.

Includes changes to conformance suite to:
- Allow calling `conformance.TestChainPair` from example tests. `CosmosChainUpgradeIBCTest` uses this to test before and after the upgrade
- Fund different random users for each `conformance.TestChainPair` run so that wallets are isolated
- Test multiple paths simultaneously