### PR TITLE
Ensure Busybox image exists before creating Busybox container 

### DIFF
--- a/internal/dockerutil/volumeowner.go
+++ b/internal/dockerutil/volumeowner.go
@@ -34,6 +34,10 @@ func SetVolumeOwner(ctx context.Context, opts VolumeOwnerOptions) error {
 
 	containerName := fmt.Sprintf("ibctest-volumeowner-%d-%s", time.Now().UnixNano(), RandLowerCaseLetterString(5))
 
+	if err := ensureBusybox(ctx, opts.Client); err != nil {
+		return err
+	}
+
 	const mountPath = "/mnt/dockervolume"
 	cc, err := opts.Client.ContainerCreate(
 		ctx,


### PR DESCRIPTION
This fixes a panic we were seeing on some tests when the user did not have the busybox image.