### PR TITLE
Create PRs into v3 on merge to main

### DIFF
--- a/.github/workflows/prior-version-pr.yml
+++ b/.github/workflows/prior-version-pr.yml
@@ -1,0 +1,20 @@
+name: PR for release branch
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release_pull_request:
+    runs-on: ubuntu-latest
+    name: release_pull_request
+    steps:
+    - name: checkout
+      uses: actions/checkout@v1
+    - name: Create PR to branch
+      uses: gorillio/github-action-cherry-pick@master
+      with:
+        pr_branch: v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITBOT_EMAIL: action@github.com
+        DRY_RUN: false


### PR DESCRIPTION
In conjunction with #283 and #284, this will cherry pick merges to `main` into a branch and open a PR against `v3`.

If changes are not applicable to v3, the PR can be closed.
If there are merge conflicts, they can be handled in the PR
