### PR TITLE
Remove cosmos specific methods from chain interface

### DIFF
--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -172,32 +172,8 @@ func (c *PenumbraChain) SendIBCTransfer(ctx context.Context, channelID, keyName 
 	return c.getRelayerNode().PenumbraAppNode.SendIBCTransfer(ctx, channelID, keyName, amount, timeout)
 }
 
-func (c *PenumbraChain) UpgradeProposal(ctx context.Context, keyName string, prop ibc.SoftwareUpgradeProposal) (ibc.SoftwareUpgradeTx, error) {
-	panic("implement me")
-}
-
-// Implements Chain interface
-func (c *PenumbraChain) InstantiateContract(ctx context.Context, keyName string, amount ibc.WalletAmount, fileName, initMessage string, needsNoAdminFlag bool) (string, error) {
-	panic("implement me")
-}
-
-// Implements Chain interface
-func (c *PenumbraChain) ExecuteContract(ctx context.Context, keyName string, contractAddress string, message string) error {
-	panic("implement me")
-}
-
-// Implements Chain interface
-func (c *PenumbraChain) DumpContractState(ctx context.Context, contractAddress string, height int64) (*ibc.DumpContractStateResponse, error) {
-	panic("implement me")
-}
-
 // Implements Chain interface
 func (c *PenumbraChain) ExportState(ctx context.Context, height int64) (string, error) {
-	panic("implement me")
-}
-
-// Implements Chain interface
-func (c *PenumbraChain) CreatePool(ctx context.Context, keyName string, contractAddress string, swapFee float64, exitFee float64, assets []ibc.WalletAmount) error {
 	panic("implement me")
 }
 

--- a/chain/polkadot/polkadot_chain.go
+++ b/chain/polkadot/polkadot_chain.go
@@ -567,36 +567,6 @@ func (c *PolkadotChain) SendIBCTransfer(ctx context.Context, channelID, keyName 
 	panic("not implemented yet")
 }
 
-// UpgradeProposal submits a software-upgrade proposal to the chain.
-// Implements Chain interface.
-func (c *PolkadotChain) UpgradeProposal(ctx context.Context, keyName string, prop ibc.SoftwareUpgradeProposal) (ibc.SoftwareUpgradeTx, error) {
-	panic("implement me")
-}
-
-// InstantiateContract takes a file path to smart contract and initialization message and returns the instantiated contract address.
-// Implements Chain interface.
-func (c *PolkadotChain) InstantiateContract(ctx context.Context, keyName string, amount ibc.WalletAmount, fileName, initMessage string, needsNoAdminFlag bool) (string, error) {
-	panic("not implemented yet")
-}
-
-// ExecuteContract executes a contract transaction with a message using it's address.
-// Implements Chain interface.
-func (c *PolkadotChain) ExecuteContract(ctx context.Context, keyName string, contractAddress string, message string) error {
-	panic("not implemented yet")
-}
-
-// DumpContractState dumps the state of a contract at a block height.
-// Implements Chain interface.
-func (c *PolkadotChain) DumpContractState(ctx context.Context, contractAddress string, height int64) (*ibc.DumpContractStateResponse, error) {
-	panic("not implemented yet")
-}
-
-// CreatePool creates a balancer pool.
-// Implements Chain interface.
-func (c *PolkadotChain) CreatePool(ctx context.Context, keyName string, contractAddress string, swapFee float64, exitFee float64, assets []ibc.WalletAmount) error {
-	panic("not implemented yet")
-}
-
 // GetBalance fetches the current balance for a specific account address and denom.
 // Implements Chain interface.
 func (c *PolkadotChain) GetBalance(ctx context.Context, address string, denom string) (int64, error) {

--- a/ibc/chain.go
+++ b/ibc/chain.go
@@ -59,21 +59,6 @@ type Chain interface {
 	// SendIBCTransfer sends an IBC transfer returning a transaction or an error if the transfer failed.
 	SendIBCTransfer(ctx context.Context, channelID, keyName string, amount WalletAmount, timeout *IBCTimeout) (Tx, error)
 
-	// UpgradeProposal submits a software-upgrade proposal to the chain.
-	UpgradeProposal(ctx context.Context, keyName string, prop SoftwareUpgradeProposal) (SoftwareUpgradeTx, error)
-
-	// InstantiateContract takes a file path to smart contract and initialization message and returns the instantiated contract address.
-	InstantiateContract(ctx context.Context, keyName string, amount WalletAmount, fileName, initMessage string, needsNoAdminFlag bool) (string, error)
-
-	// ExecuteContract executes a contract transaction with a message using it's address.
-	ExecuteContract(ctx context.Context, keyName string, contractAddress string, message string) error
-
-	// DumpContractState dumps the state of a contract at a block height.
-	DumpContractState(ctx context.Context, contractAddress string, height int64) (*DumpContractStateResponse, error)
-
-	// CreatePool creates a balancer pool.
-	CreatePool(ctx context.Context, keyName string, contractAddress string, swapFee float64, exitFee float64, assets []WalletAmount) error
-
 	// Height returns the current block height or an error if unable to get current height.
 	Height(ctx context.Context) (uint64, error)
 


### PR DESCRIPTION
These methods are only applicable to cosmos chains for now, so they can be removed from the `ibc.Chain` interface. Tests that want to use these methods can cast the chain to a `*CosmosChain`.