### PR TITLE
[v3] Proposal Polling and Pools

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -693,12 +692,12 @@ func (tn *ChainNode) VoteOnProposal(ctx context.Context, keyName string, proposa
 }
 
 // QueryProposal returns the status of a proposal.
-func (tn *ChainNode) QueryProposal(ctx context.Context, proposalID string) (*govtypes.Proposal, error) {
+func (tn *ChainNode) QueryProposal(ctx context.Context, proposalID string) (*ibc.ProposalResponse, error) {
 	stdout, _, err := tn.ExecQuery(ctx, "gov", "proposal", proposalID)
 	if err != nil {
 		return nil, err
 	}
-	var proposal govtypes.Proposal
+	var proposal ibc.ProposalResponse
 	err = json.Unmarshal(stdout, &proposal)
 	if err != nil {
 		return nil, err

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types"
 	authTx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	chanTypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	dockertypes "github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
@@ -271,7 +270,7 @@ func (c *CosmosChain) SendIBCTransfer(ctx context.Context, channelID, keyName st
 }
 
 // Implements Chain interface
-func (c *CosmosChain) QueryProposal(ctx context.Context, proposalID string) (*govtypes.Proposal, error) {
+func (c *CosmosChain) QueryProposal(ctx context.Context, proposalID string) (*ibc.ProposalResponse, error) {
 	return c.getFullNode().QueryProposal(ctx, proposalID)
 }
 

--- a/chain/cosmos/osmosis.go
+++ b/chain/cosmos/osmosis.go
@@ -1,0 +1,66 @@
+package cosmos
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/strangelove-ventures/ibctest/v3/internal/dockerutil"
+)
+
+// OsmosisPoolParams defines parameters for creating an osmosis gamm liquidity pool
+type OsmosisPoolParams struct {
+	Weights        string `json:"weights"`
+	InitialDeposit string `json:"initial-deposit"`
+	SwapFee        string `json:"swap-fee"`
+	ExitFee        string `json:"exit-fee"`
+	FutureGovernor string `json:"future-governor"`
+}
+
+func OsmosisCreatePool(c *CosmosChain, ctx context.Context, keyName string, params OsmosisPoolParams) (string, error) {
+	tn := c.getFullNode()
+	poolbz, err := json.Marshal(params)
+	if err != nil {
+		return "", err
+	}
+
+	poolFile := "pool.json"
+
+	fw := dockerutil.NewFileWriter(tn.logger(), tn.DockerClient, tn.TestName)
+	if err := fw.WriteFile(ctx, tn.VolumeName, poolFile, poolbz); err != nil {
+		return "", fmt.Errorf("failed to write pool file: %w", err)
+	}
+
+	if _, err := tn.ExecTx(ctx, keyName,
+		"gamm", "create-pool",
+		"--pool-file", filepath.Join(tn.HomeDir(), poolFile),
+	); err != nil {
+		return "", fmt.Errorf("failed to create pool: %w", err)
+	}
+
+	stdout, _, err := tn.ExecQuery(ctx, "gamm", "num-pools")
+	if err != nil {
+		return "", fmt.Errorf("failed to query num pools: %w", err)
+	}
+	var res map[string]string
+	if err := json.Unmarshal(stdout, &res); err != nil {
+		return "", fmt.Errorf("failed to unmarshal query response: %w", err)
+	}
+
+	numPools, ok := res["num_pools"]
+	if !ok {
+		return "", fmt.Errorf("could not find number of pools in query response: %w", err)
+	}
+	return numPools, nil
+}
+
+func OsmosisSwapExactAmountIn(c *CosmosChain, ctx context.Context, keyName string, coinIn string, minAmountOut string, poolIDs []string, swapDenoms []string) (string, error) {
+	return c.getFullNode().ExecTx(ctx, keyName,
+		"gamm", "swap-exact-amount-in",
+		coinIn, minAmountOut,
+		"--swap-route-pool-ids", strings.Join(poolIDs, ","),
+		"--swap-route-denoms", strings.Join(swapDenoms, ","),
+	)
+}

--- a/chain/cosmos/poll.go
+++ b/chain/cosmos/poll.go
@@ -22,5 +22,8 @@ func PollForProposalStatus(ctx context.Context, chain *CosmosChain, startHeight,
 	}
 	bp := test.BlockPoller{CurrentHeight: chain.Height, PollFunc: doPoll}
 	p, err := bp.DoPoll(ctx, startHeight, maxHeight)
-	return p.(ProposalResponse), err
+	if err != nil {
+		return zero, err
+	}
+	return p.(ProposalResponse), nil
 }

--- a/chain/cosmos/poll.go
+++ b/chain/cosmos/poll.go
@@ -18,7 +18,7 @@ func PollForProposalStatus(ctx context.Context, chain *CosmosChain, startHeight,
 		if p.Status != status {
 			return zero, fmt.Errorf("proposal status (%s) does not match expected: (%s)", p.Status, status)
 		}
-		return p, nil
+		return *p, nil
 	}
 	bp := test.BlockPoller{CurrentHeight: chain.Height, PollFunc: doPoll}
 	p, err := bp.DoPoll(ctx, startHeight, maxHeight)

--- a/chain/cosmos/poll.go
+++ b/chain/cosmos/poll.go
@@ -1,0 +1,25 @@
+package cosmos
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/strangelove-ventures/ibctest/v3/test"
+)
+
+// PollForProposalStatus attempts to find a proposal with matching ID and status.
+func PollForProposalStatus(ctx context.Context, chain *CosmosChain, startHeight, maxHeight uint64, proposalID string, status string) (*ProposalResponse, error) {
+	doPoll := func(ctx context.Context, height uint64) (any, error) {
+		p, err := chain.QueryProposal(ctx, proposalID)
+		if err != nil {
+			return nil, err
+		}
+		if p.Status != status {
+			return nil, fmt.Errorf("proposal status (%s) does not match expected: (%s)", p.Status, status)
+		}
+		return p, nil
+	}
+	bp := test.BlockPoller{CurrentHeight: chain.Height, PollFunc: doPoll}
+	p, err := bp.DoPoll(ctx, startHeight, maxHeight)
+	return p.(*ProposalResponse), err
+}

--- a/chain/cosmos/poll.go
+++ b/chain/cosmos/poll.go
@@ -8,18 +8,19 @@ import (
 )
 
 // PollForProposalStatus attempts to find a proposal with matching ID and status.
-func PollForProposalStatus(ctx context.Context, chain *CosmosChain, startHeight, maxHeight uint64, proposalID string, status string) (*ProposalResponse, error) {
+func PollForProposalStatus(ctx context.Context, chain *CosmosChain, startHeight, maxHeight uint64, proposalID string, status string) (ProposalResponse, error) {
+	var zero ProposalResponse
 	doPoll := func(ctx context.Context, height uint64) (any, error) {
 		p, err := chain.QueryProposal(ctx, proposalID)
 		if err != nil {
-			return nil, err
+			return zero, err
 		}
 		if p.Status != status {
-			return nil, fmt.Errorf("proposal status (%s) does not match expected: (%s)", p.Status, status)
+			return zero, fmt.Errorf("proposal status (%s) does not match expected: (%s)", p.Status, status)
 		}
 		return p, nil
 	}
 	bp := test.BlockPoller{CurrentHeight: chain.Height, PollFunc: doPoll}
 	p, err := bp.DoPoll(ctx, startHeight, maxHeight)
-	return p.(*ProposalResponse), err
+	return p.(ProposalResponse), err
 }

--- a/chain/cosmos/types.go
+++ b/chain/cosmos/types.go
@@ -1,0 +1,90 @@
+package cosmos
+
+const (
+	ProposalVoteYes        = "yes"
+	ProposalVoteNo         = "no"
+	ProposalVoteNoWithVeto = "noWithVeto"
+	ProposalVoteAbstain    = "abstain"
+
+	ProposalStatusUnspecified   = "PROPOSAL_STATUS_UNSPECIFIED"
+	ProposalStatusPassed        = "PROPOSAL_STATUS_PASSED"
+	ProposalStatusFailed        = "PROPOSAL_STATUS_FAILED"
+	ProposalStatusRejected      = "PROPOSAL_STATUS_REJECTED"
+	ProposalStatusVotingPeriod  = "PROPOSAL_STATUS_VOTING_PERIOD"
+	ProposalStatusDepositPeriod = "PROPOSAL_STATUS_DEPOSIT_PERIOD"
+)
+
+// TxProposal contains chain proposal transaction details.
+type TxProposal struct {
+	// The block height.
+	Height uint64
+	// The transaction hash.
+	TxHash string
+	// Amount of gas charged to the account.
+	GasSpent int64
+
+	// Amount deposited for proposal.
+	DepositAmount string
+	// ID of proposal.
+	ProposalID string
+	// Type of proposal.
+	ProposalType string
+}
+
+// SoftwareUpgradeProposal defines the required and optional parameters for submitting a software-upgrade proposal.
+type TextProposal struct {
+	Deposit     string
+	Title       string
+	Description string
+	Expedited   bool
+}
+
+// SoftwareUpgradeProposal defines the required and optional parameters for submitting a software-upgrade proposal.
+type SoftwareUpgradeProposal struct {
+	Deposit     string
+	Title       string
+	Name        string
+	Description string
+	Height      uint64
+	Info        string // optional
+}
+
+// ProposalResponse is the proposal query response.
+type ProposalResponse struct {
+	ProposalID       string                   `json:"proposal_id"`
+	Content          ProposalContent          `json:"content"`
+	Status           string                   `json:"status"`
+	FinalTallyResult ProposalFinalTallyResult `json:"final_tally_result"`
+	SubmitTime       string                   `json:"submit_time"`
+	DepositEndTime   string                   `json:"deposit_end_time"`
+	TotalDeposit     []ProposalDeposit        `json:"total_deposit"`
+	VotingStartTime  string                   `json:"voting_start_time"`
+	VotingEndTime    string                   `json:"voting_end_time"`
+}
+
+type ProposalContent struct {
+	Type        string `json:"@type"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+type ProposalFinalTallyResult struct {
+	Yes        string `json:"yes"`
+	Abstain    string `json:"abstain"`
+	No         string `json:"no"`
+	NoWithVeto string `json:"no_with_veto"`
+}
+
+type ProposalDeposit struct {
+	Denom  string `json:"denom"`
+	Amount string `json:"amount"`
+}
+
+type DumpContractStateResponse struct {
+	Models []ContractStateModels `json:"models"`
+}
+
+type ContractStateModels struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}

--- a/examples/cosmos_chain_upgrade_ibc_test.go
+++ b/examples/cosmos_chain_upgrade_ibc_test.go
@@ -100,7 +100,7 @@ func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeV
 
 	haltHeight := height + haltHeightDelta
 
-	proposal := ibc.SoftwareUpgradeProposal{
+	proposal := cosmos.SoftwareUpgradeProposal{
 		Deposit:     "500000000" + chain.Config().Denom, // greater than min deposit
 		Title:       "Chain Upgrade 1",
 		Name:        upgradeName,
@@ -111,8 +111,11 @@ func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeV
 	upgradeTx, err := chain.UpgradeProposal(ctx, chainUser.KeyName, proposal)
 	require.NoError(t, err, "error submitting software upgrade proposal tx")
 
-	err = chain.VoteOnProposalAllValidators(ctx, upgradeTx.ProposalID, ibc.ProposalVoteYes)
+	err = chain.VoteOnProposalAllValidators(ctx, upgradeTx.ProposalID, cosmos.ProposalVoteYes)
 	require.NoError(t, err, "failed to submit votes")
+
+	_, err = cosmos.PollForProposalStatus(ctx, chain, height, height+haltHeightDelta, upgradeTx.ProposalID, cosmos.ProposalStatusPassed)
+	require.NoError(t, err, "proposal status did not change to passed in expected number of blocks")
 
 	height, err = chain.Height(ctx)
 	require.NoError(t, err, "error fetching height before upgrade")

--- a/ibc/tx.go
+++ b/ibc/tx.go
@@ -32,34 +32,3 @@ func (tx Tx) Validate() error {
 	}
 	return multierr.Append(err, tx.Packet.Validate())
 }
-
-const (
-	ProposalVoteYes        = "yes"
-	ProposalVoteNo         = "no"
-	ProposalVoteNoWithVeto = "noWithVeto"
-	ProposalVoteAbstain    = "abstain"
-
-	ProposalStatusUnspecified   = "PROPOSAL_STATUS_UNSPECIFIED"
-	ProposalStatusPassed        = "PROPOSAL_STATUS_PASSED"
-	ProposalStatusFailed        = "PROPOSAL_STATUS_FAILED"
-	ProposalStatusRejected      = "PROPOSAL_STATUS_REJECTED"
-	ProposalStatusVotingPeriod  = "PROPOSAL_STATUS_VOTING_PERIOD"
-	ProposalStatusDepositPeriod = "PROPOSAL_STATUS_DEPOSIT_PERIOD"
-)
-
-// TxProposal contains chain proposal transaction details.
-type TxProposal struct {
-	// The block height.
-	Height uint64
-	// The transaction hash.
-	TxHash string
-	// Amount of gas charged to the account.
-	GasSpent int64
-
-	// Amount deposited for proposal.
-	DepositAmount string
-	// ID of proposal.
-	ProposalID string
-	// Type of proposal.
-	ProposalType string
-}

--- a/ibc/tx.go
+++ b/ibc/tx.go
@@ -38,10 +38,17 @@ const (
 	ProposalVoteNo         = "no"
 	ProposalVoteNoWithVeto = "noWithVeto"
 	ProposalVoteAbstain    = "abstain"
+
+	ProposalStatusUnspecified   = "PROPOSAL_STATUS_UNSPECIFIED"
+	ProposalStatusPassed        = "PROPOSAL_STATUS_PASSED"
+	ProposalStatusFailed        = "PROPOSAL_STATUS_FAILED"
+	ProposalStatusRejected      = "PROPOSAL_STATUS_REJECTED"
+	ProposalStatusVotingPeriod  = "PROPOSAL_STATUS_VOTING_PERIOD"
+	ProposalStatusDepositPeriod = "PROPOSAL_STATUS_DEPOSIT_PERIOD"
 )
 
-// SoftwareUpgradeTx is a generalized IBC transaction.
-type SoftwareUpgradeTx struct {
+// TxProposal contains chain proposal transaction details.
+type TxProposal struct {
 	// The block height.
 	Height uint64
 	// The transaction hash.

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -139,15 +139,6 @@ type IBCTimeout struct {
 	Height      uint64
 }
 
-type ContractStateModels struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-type DumpContractStateResponse struct {
-	Models []ContractStateModels `json:"models"`
-}
-
 type ChannelCounterparty struct {
 	PortID    string `json:"port_id"`
 	ChannelID string `json:"channel_id"`
@@ -195,60 +186,3 @@ const (
 	CosmosRly RelayerImplementation = iota
 	Hermes
 )
-
-// SoftwareUpgradeProposal defines the required and optional parameters for submitting a software-upgrade proposal.
-type TextProposal struct {
-	Deposit     string
-	Title       string
-	Description string
-	Expedited   bool
-}
-
-// SoftwareUpgradeProposal defines the required and optional parameters for submitting a software-upgrade proposal.
-type SoftwareUpgradeProposal struct {
-	Deposit     string
-	Title       string
-	Name        string
-	Description string
-	Height      uint64
-	Info        string // optional
-}
-
-// PoolParams defines parameters for creating a gamm liquidity pool
-type PoolParams struct {
-	Weights        string `json:"weights"`
-	InitialDeposit string `json:"initial-deposit"`
-	SwapFee        string `json:"swap-fee"`
-	ExitFee        string `json:"exit-fee"`
-	FutureGovernor string `json:"future-governor"`
-}
-
-type ProposalResponse struct {
-	ProposalID       string                   `json:"proposal_id"`
-	Content          ProposalContent          `json:"content"`
-	Status           string                   `json:"status"`
-	FinalTallyResult ProposalFinalTallyResult `json:"final_tally_result"`
-	SubmitTime       string                   `json:"submit_time"`
-	DepositEndTime   string                   `json:"deposit_end_time"`
-	TotalDeposit     []ProposalDeposit        `json:"total_deposit"`
-	VotingStartTime  string                   `json:"voting_start_time"`
-	VotingEndTime    string                   `json:"voting_end_time"`
-}
-
-type ProposalContent struct {
-	Type        string `json:"@type"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-}
-
-type ProposalFinalTallyResult struct {
-	Yes        string `json:"yes"`
-	Abstain    string `json:"abstain"`
-	No         string `json:"no"`
-	NoWithVeto string `json:"no_with_veto"`
-}
-
-type ProposalDeposit struct {
-	Denom  string `json:"denom"`
-	Amount string `json:"amount"`
-}

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -197,6 +197,14 @@ const (
 )
 
 // SoftwareUpgradeProposal defines the required and optional parameters for submitting a software-upgrade proposal.
+type TextProposal struct {
+	Deposit     string
+	Title       string
+	Description string
+	Expedited   bool
+}
+
+// SoftwareUpgradeProposal defines the required and optional parameters for submitting a software-upgrade proposal.
 type SoftwareUpgradeProposal struct {
 	Deposit     string
 	Title       string
@@ -204,4 +212,13 @@ type SoftwareUpgradeProposal struct {
 	Description string
 	Height      uint64
 	Info        string // optional
+}
+
+// PoolParams defines parameters for creating a gamm liquidity pool
+type PoolParams struct {
+	Weights        string `json:"weights"`
+	InitialDeposit string `json:"initial-deposit"`
+	SwapFee        string `json:"swap-fee"`
+	ExitFee        string `json:"exit-fee"`
+	FutureGovernor string `json:"future-governor"`
 }

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -222,3 +222,33 @@ type PoolParams struct {
 	ExitFee        string `json:"exit-fee"`
 	FutureGovernor string `json:"future-governor"`
 }
+
+type ProposalResponse struct {
+	ProposalID       string                   `json:"proposal_id"`
+	Content          ProposalContent          `json:"content"`
+	Status           string                   `json:"status"`
+	FinalTallyResult ProposalFinalTallyResult `json:"final_tally_result"`
+	SubmitTime       string                   `json:"submit_time"`
+	DepositEndTime   string                   `json:"deposit_end_time"`
+	TotalDeposit     []ProposalDeposit        `json:"total_deposit"`
+	VotingStartTime  string                   `json:"voting_start_time"`
+	VotingEndTime    string                   `json:"voting_end_time"`
+}
+
+type ProposalContent struct {
+	Type        string `json:"@type"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+type ProposalFinalTallyResult struct {
+	Yes        string `json:"yes"`
+	Abstain    string `json:"abstain"`
+	No         string `json:"no"`
+	NoWithVeto string `json:"no_with_veto"`
+}
+
+type ProposalDeposit struct {
+	Denom  string `json:"denom"`
+	Amount string `json:"amount"`
+}

--- a/test/poll_for_state.go
+++ b/test/poll_for_state.go
@@ -12,81 +12,17 @@ import (
 
 var ErrNotFound = errors.New("not found")
 
-// ChainAcker is a chain that can get its acknowledgements at a specified height
-type ChainAcker interface {
-	ChainHeighter
-	Acknowledgements(ctx context.Context, height uint64) ([]ibc.PacketAcknowledgement, error)
+type BlockPoller struct {
+	CurrentHeight func(ctx context.Context) (uint64, error)
+	PollFunc      func(ctx context.Context, height uint64) (any, error)
 }
 
-// PollForAck attempts to find an acknowledgement containing a packet equal to the packet argument.
-// Polling starts at startHeight and continues until maxHeight. It is safe to call this function even if
-// the chain has yet to produce blocks for the target min/max height range. Polling delays until heights exist
-// on the chain. Returns an error if acknowledgement not found or problems getting height or acknowledgements.
-func PollForAck(ctx context.Context, chain ChainAcker, startHeight, maxHeight uint64, packet ibc.Packet) (ibc.PacketAcknowledgement, error) {
-	poller := blockPoller{CurrentHeight: chain.Height, Acker: chain}
-	found, err := poller.doPoll(ctx, startHeight, maxHeight, packet)
-	if err != nil {
-		return ibc.PacketAcknowledgement{}, err
-	}
-	return found.(ibc.PacketAcknowledgement), nil
-}
-
-// ChainTimeouter is a chain that can get its timeouts at a specified height
-type ChainTimeouter interface {
-	ChainHeighter
-	Timeouts(ctx context.Context, height uint64) ([]ibc.PacketTimeout, error)
-}
-
-// PollForTimeout attempts to find a timeout containing a packet equal to the packet argument.
-// Otherwise, works identically to PollForAck.
-func PollForTimeout(ctx context.Context, chain ChainTimeouter, startHeight, maxHeight uint64, packet ibc.Packet) (ibc.PacketTimeout, error) {
-	poller := blockPoller{CurrentHeight: chain.Height, Timeouter: chain}
-	found, err := poller.doPoll(ctx, startHeight, maxHeight, packet)
-	if err != nil {
-		return ibc.PacketTimeout{}, err
-	}
-	return found.(ibc.PacketTimeout), nil
-}
-
-type ChainProposalStatuser interface {
-	ChainHeighter
-	QueryProposal(ctx context.Context, proposalID string) (*ibc.ProposalResponse, error)
-}
-
-type proposalSearch struct {
-	id     string
-	status string
-}
-
-// PollForTimeout attempts to find a timeout containing a packet equal to the packet argument.
-// Otherwise, works identically to PollForAck.
-func PollForProposalStatus(ctx context.Context, chain ChainProposalStatuser, startHeight, maxHeight uint64, proposalID string, status string) error {
-	poller := blockPoller{CurrentHeight: chain.Height, ProposalStatuser: chain}
-	_, err := poller.doPoll(ctx, startHeight, maxHeight, proposalSearch{
-		id:     proposalID,
-		status: status,
-	})
-	return err
-}
-
-type blockPoller struct {
-	CurrentHeight    func(ctx context.Context) (uint64, error)
-	Acker            ChainAcker
-	Timeouter        ChainTimeouter
-	ProposalStatuser ChainProposalStatuser
-	pollErr          *pollError
-}
-
-func (p blockPoller) doPoll(ctx context.Context, startHeight, maxHeight uint64, pollData any) (any, error) {
+func (p BlockPoller) DoPoll(ctx context.Context, startHeight, maxHeight uint64) (any, error) {
 	if maxHeight < startHeight {
 		panic("maxHeight must be greater than or equal to startHeight")
 	}
-	switch {
-	case p.Acker != nil, p.Timeouter != nil:
-		p.pollErr = &pollError{targetPacket: pollData.(ibc.Packet)}
-	default:
-		p.pollErr = &pollError{}
-	}
+
+	var pollErr error
 
 	cursor := startHeight
 	for cursor <= maxHeight {
@@ -98,99 +34,111 @@ func (p blockPoller) doPoll(ctx context.Context, startHeight, maxHeight uint64, 
 			continue
 		}
 
-		var (
-			found   any
-			findErr error
-		)
-		switch {
-		case p.Acker != nil:
-			found, findErr = p.findAck(ctx, cursor, pollData.(ibc.Packet))
-		case p.Timeouter != nil:
-			found, findErr = p.findTimeout(ctx, cursor, pollData.(ibc.Packet))
-		case p.ProposalStatuser != nil:
-			findErr = p.findProposalStatus(ctx, cursor, pollData.(proposalSearch))
-		default:
-			panic("poller misconfiguration")
-		}
+		found, findErr := p.PollFunc(ctx, curHeight)
 
 		if findErr != nil {
-			p.pollErr.SetErr(findErr)
+			pollErr = err
 			cursor++
 			continue
 		}
 
 		return found, nil
 	}
-	return nil, p.pollErr
+	return nil, pollErr
 }
 
-func (p blockPoller) findAck(ctx context.Context, height uint64, packet ibc.Packet) (ibc.PacketAcknowledgement, error) {
-	var zero ibc.PacketAcknowledgement
-	acks, err := p.Acker.Acknowledgements(ctx, height)
-	if err != nil {
-		return zero, err
-	}
-	for _, ack := range acks {
-		p.pollErr.PushSearched(ack)
-		if ack.Packet.Equal(packet) {
-			return ack, nil
+// ChainAcker is a chain that can get its acknowledgements at a specified height
+type ChainAcker interface {
+	ChainHeighter
+	Acknowledgements(ctx context.Context, height uint64) ([]ibc.PacketAcknowledgement, error)
+}
+
+// PollForAck attempts to find an acknowledgement containing a packet equal to the packet argument.
+// Polling starts at startHeight and continues until maxHeight. It is safe to call this function even if
+// the chain has yet to produce blocks for the target min/max height range. Polling delays until heights exist
+// on the chain. Returns an error if acknowledgement not found or problems getting height or acknowledgements.
+func PollForAck(ctx context.Context, chain ChainAcker, startHeight, maxHeight uint64, packet ibc.Packet) (*ibc.PacketAcknowledgement, error) {
+	pollError := new(packetPollError)
+	poll := func(ctx context.Context, height uint64) (any, error) {
+		acks, err := chain.Acknowledgements(ctx, height)
+		if err != nil {
+			return nil, err
 		}
-	}
-	return zero, ErrNotFound
-}
-
-func (p blockPoller) findTimeout(ctx context.Context, height uint64, packet ibc.Packet) (ibc.PacketTimeout, error) {
-	var zero ibc.PacketTimeout
-	timeouts, err := p.Timeouter.Timeouts(ctx, height)
-	if err != nil {
-		return zero, err
-	}
-	for _, t := range timeouts {
-		p.pollErr.PushSearched(t)
-		if t.Packet.Equal(packet) {
-			return t, nil
+		for _, ack := range acks {
+			pollError.PushSearched(ack)
+			if ack.Packet.Equal(packet) {
+				return &ack, nil
+			}
 		}
+		return nil, ErrNotFound
 	}
-	return zero, ErrNotFound
-}
 
-func (p blockPoller) findProposalStatus(ctx context.Context, height uint64, proposal proposalSearch) error {
-	res, err := p.ProposalStatuser.QueryProposal(ctx, proposal.id)
+	poller := BlockPoller{CurrentHeight: chain.Height, PollFunc: poll}
+	found, err := poller.DoPoll(ctx, startHeight, maxHeight)
 	if err != nil {
-		return err
+		pollError.SetErr(err)
+		return nil, pollError
 	}
-	if res.Status != proposal.status {
-		return fmt.Errorf("status: (%s) is not equal to expected: (%s)", res.Status, proposal.status)
-	}
-	return nil
+	return found.(*ibc.PacketAcknowledgement), nil
 }
 
-type pollError struct {
+// ChainTimeouter is a chain that can get its timeouts at a specified height
+type ChainTimeouter interface {
+	ChainHeighter
+	Timeouts(ctx context.Context, height uint64) ([]ibc.PacketTimeout, error)
+}
+
+// PollForAck attempts to find an acknowledgement containing a packet equal to the packet argument.
+// Polling starts at startHeight and continues until maxHeight. It is safe to call this function even if
+// the chain has yet to produce blocks for the target min/max height range. Polling delays until heights exist
+// on the chain. Returns an error if acknowledgement not found or problems getting height or acknowledgements.
+func PollForTimeout(ctx context.Context, chain ChainTimeouter, startHeight, maxHeight uint64, packet ibc.Packet) (*ibc.PacketAcknowledgement, error) {
+	pollError := new(packetPollError)
+	poll := func(ctx context.Context, height uint64) (any, error) {
+		timeouts, err := chain.Timeouts(ctx, height)
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range timeouts {
+			pollError.PushSearched(t)
+			if t.Packet.Equal(packet) {
+				return &t, nil
+			}
+		}
+		return nil, ErrNotFound
+	}
+
+	poller := BlockPoller{CurrentHeight: chain.Height, PollFunc: poll}
+	found, err := poller.DoPoll(ctx, startHeight, maxHeight)
+	if err != nil {
+		pollError.SetErr(err)
+		return nil, pollError
+	}
+	return found.(*ibc.PacketAcknowledgement), nil
+}
+
+type packetPollError struct {
 	error
 	targetPacket    ibc.Packet
 	searchedPackets []string
 }
 
-func (pe *pollError) SetErr(err error) {
+func (pe *packetPollError) SetErr(err error) {
 	pe.error = err
 }
 
-func (pe *pollError) PushSearched(packet any) {
+func (pe *packetPollError) PushSearched(packet any) {
 	pe.searchedPackets = append(pe.searchedPackets, spew.Sdump(packet))
 }
 
-func (pe *pollError) Unwrap() error {
+func (pe *packetPollError) Unwrap() error {
 	return pe.error
 }
 
 // Format is expected to be used by testify/require which prints errors via %+v
-func (pe *pollError) Format(s fmt.State, verb rune) {
+func (pe *packetPollError) Format(s fmt.State, verb rune) {
 	if verb != 'v' && !s.Flag('+') {
 		fmt.Fprint(s, pe.error.Error())
-		return
-	}
-
-	if pe.targetPacket.Sequence == 0 {
 		return
 	}
 

--- a/test/poll_for_state.go
+++ b/test/poll_for_state.go
@@ -34,11 +34,10 @@ func (p BlockPoller) DoPoll(ctx context.Context, startHeight, maxHeight uint64) 
 			continue
 		}
 
-		found, findErr := p.PollFunc(ctx, curHeight)
+		found, findErr := p.PollFunc(ctx, cursor)
 
 		if findErr != nil {
 			pollErr = findErr
-			fmt.Printf("found err: %v\n", findErr)
 			cursor++
 			continue
 		}
@@ -62,7 +61,6 @@ func PollForAck(ctx context.Context, chain ChainAcker, startHeight, maxHeight ui
 	var zero ibc.PacketAcknowledgement
 	pollError := &packetPollError{targetPacket: packet}
 	poll := func(ctx context.Context, height uint64) (any, error) {
-
 		acks, err := chain.Acknowledgements(ctx, height)
 		if err != nil {
 			return zero, err
@@ -91,10 +89,8 @@ type ChainTimeouter interface {
 	Timeouts(ctx context.Context, height uint64) ([]ibc.PacketTimeout, error)
 }
 
-// PollForAck attempts to find an acknowledgement containing a packet equal to the packet argument.
-// Polling starts at startHeight and continues until maxHeight. It is safe to call this function even if
-// the chain has yet to produce blocks for the target min/max height range. Polling delays until heights exist
-// on the chain. Returns an error if acknowledgement not found or problems getting height or acknowledgements.
+// PollForTimeout attempts to find a timeout containing a packet equal to the packet argument.
+// Otherwise, works identically to PollForAck.
 func PollForTimeout(ctx context.Context, chain ChainTimeouter, startHeight, maxHeight uint64, packet ibc.Packet) (ibc.PacketTimeout, error) {
 	pollError := &packetPollError{targetPacket: packet}
 	var zero ibc.PacketTimeout


### PR DESCRIPTION
Add methods to `CosmosChain`:
- `QueryProposal` to fetch proposal information e.g. title, description, status, etc.
- `TextProposal` to submit a text governance proposal

Adds `cosmos.PollForProposalStatus` to poll for a proposal to change status, e.g. wait for proposal to transition from voting period to pass/fail status.

`CreatePool` was never fully implemented. This is used in #282 
Osmosis specific methods in their own file