### PR TITLE
move builtin chains to yaml file

### DIFF
--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -57,29 +57,6 @@ type PenumbraGenesisAppStateAllocation struct {
 	Address string `json:"address"`
 }
 
-func NewPenumbraChainConfig() ibc.ChainConfig {
-	return ibc.ChainConfig{
-		Type:           "penumbra",
-		Name:           "penumbra",
-		Bech32Prefix:   "penumbra",
-		Denom:          "upenumbra",
-		GasPrices:      "0.0upenumbra",
-		GasAdjustment:  1.3,
-		TrustingPeriod: "672h",
-		Images: []ibc.DockerImage{
-			{
-				Repository: "ghcr.io/strangelove-ventures/heighliner/tendermint",
-				UidGid:     dockerutil.GetHeighlinerUserString(),
-			},
-			{
-				Repository: "ghcr.io/strangelove-ventures/heighliner/penumbra",
-				UidGid:     dockerutil.GetHeighlinerUserString(),
-			},
-		},
-		Bin: "tendermint",
-	}
-}
-
 func NewPenumbraChain(log *zap.Logger, testName string, chainConfig ibc.ChainConfig, numValidators int, numFullNodes int) *PenumbraChain {
 	return &PenumbraChain{
 		log:           log,

--- a/chain/polkadot/polkadot_chain.go
+++ b/chain/polkadot/polkadot_chain.go
@@ -64,31 +64,6 @@ type ParachainConfig struct {
 // IndexedName is a slice of the substrate dev key names used for key derivation.
 var IndexedName = []string{"alice", "bob", "charlie", "dave", "ferdie"}
 
-// NewComposableChainConfig returns an ibc.ChainConfig for configuring a polkadot relay chain and composable parachain.
-func NewComposableChainConfig() ibc.ChainConfig {
-	return ibc.ChainConfig{
-		Type:         "polkadot",
-		Name:         "composable",
-		Bech32Prefix: "",
-		Denom:        "uDOT",
-		// TODO maybe use these params for the weight-based fee model
-		GasPrices:      "",
-		GasAdjustment:  0,
-		TrustingPeriod: "",
-		Images: []ibc.DockerImage{
-			{
-				Repository: "ghcr.io/strangelove-ventures/heighliner/polkadot",
-				UidGid:     dockerutil.GetHeighlinerUserString(),
-			},
-			{
-				Repository: "ghcr.io/strangelove-ventures/heighliner/composable",
-				UidGid:     dockerutil.GetHeighlinerUserString(),
-			},
-		},
-		Bin: "polkadot",
-	}
-}
-
 // NewPolkadotChain returns an uninitialized PolkadotChain, which implements the ibc.Chain interface.
 func NewPolkadotChain(log *zap.Logger, testName string, chainConfig ibc.ChainConfig, numRelayChainNodes int, parachains []ParachainConfig) *PolkadotChain {
 	return &PolkadotChain{

--- a/chainfactory.go
+++ b/chainfactory.go
@@ -56,7 +56,8 @@ func initBuiltinChainConfig() (map[string]ibc.ChainConfig, error) {
 	configuredChainsFile := ""
 	if _, err := os.Stat("./configuredChains.yaml"); err == nil {
 		configuredChainsFile = "./configuredChains.yaml"
-	} else if os.Stat("../configuredChains.yaml"); err == nil {
+	}
+	if _, err := os.Stat("../configuredChains.yaml"); err == nil {
 		configuredChainsFile = "../configuredChains.yaml"
 	}
 

--- a/chainfactory.go
+++ b/chainfactory.go
@@ -2,6 +2,7 @@ package ibctest
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/strangelove-ventures/ibctest/v5/chain/cosmos"
@@ -10,6 +11,7 @@ import (
 	"github.com/strangelove-ventures/ibctest/v5/ibc"
 	"github.com/strangelove-ventures/ibctest/v5/label"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 )
 
 // ChainFactory describes how to get chains for tests.
@@ -42,16 +44,18 @@ type BuiltinChainFactory struct {
 	specs []*ChainSpec
 }
 
-// builtinChainConfigs is a mapping of valid builtin chain names
-// to their predefined ibc.ChainConfig.
-var builtinChainConfigs = map[string]ibc.ChainConfig{
-	"gaia":       cosmos.NewCosmosHeighlinerChainConfig("gaia", "gaiad", "cosmos", "uatom", "0.01uatom", 1.3, "504h", false),
-	"osmosis":    cosmos.NewCosmosHeighlinerChainConfig("osmosis", "osmosisd", "osmo", "uosmo", "0.0uosmo", 1.3, "336h", false),
-	"juno":       cosmos.NewCosmosHeighlinerChainConfig("juno", "junod", "juno", "ujuno", "0.0025ujuno", 1.3, "672h", false),
-	"agoric":     cosmos.NewCosmosHeighlinerChainConfig("agoric", "agd", "agoric", "urun", "0.01urun", 1.3, "672h", true),
-	"icad":       cosmos.NewCosmosHeighlinerChainConfig("icad", "icad", "cosmos", "photon", "0.00photon", 1.2, "504h", false),
-	"penumbra":   penumbra.NewPenumbraChainConfig(),
-	"composable": polkadot.NewComposableChainConfig(),
+// initBuiltinChainConfig returns an ibc.ChainConfig mapping all configured chains
+func initBuiltinChainConfig() (map[string]ibc.ChainConfig, error) {
+	dat, err := os.ReadFile("./configuredChains.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("error reading configuredChains.yaml: %v", err)
+	}
+	builtinChainConfigs := make(map[string]ibc.ChainConfig)
+	err = yaml.Unmarshal(dat, &builtinChainConfigs)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing configuredChains.yaml: %v", err)
+	}
+	return builtinChainConfigs, nil
 }
 
 // NewBuiltinChainFactory returns a BuiltinChainFactory that returns chains defined by entries.

--- a/chainfactory.go
+++ b/chainfactory.go
@@ -46,13 +46,13 @@ type BuiltinChainFactory struct {
 }
 
 //go:embed configuredChains.yaml
-var embededConfiguredChains []byte
+var embeddedConfiguredChains []byte
 
 // initBuiltinChainConfig returns an ibc.ChainConfig mapping all configured chains
 func initBuiltinChainConfig() (map[string]ibc.ChainConfig, error) {
 
 	// checks if configuredChains.yaml is found in cwd or parent of cwd,
-	// otherwise it will use the the embeded version of configuredChains.yaml
+	// otherwise it will use the the embedded version of configuredChains.yaml
 	configuredChainsFile := ""
 	if _, err := os.Stat("./configuredChains.yaml"); err == nil {
 		configuredChainsFile = "./configuredChains.yaml"
@@ -70,7 +70,7 @@ func initBuiltinChainConfig() (map[string]ibc.ChainConfig, error) {
 			return nil, fmt.Errorf("error reading configuredChains.yaml: %v", err)
 		}
 	} else {
-		dat = embededConfiguredChains
+		dat = embeddedConfiguredChains
 	}
 
 	err = yaml.Unmarshal(dat, &builtinChainConfigs)

--- a/chainfactory.go
+++ b/chainfactory.go
@@ -49,7 +49,7 @@ type BuiltinChainFactory struct {
 //go:embed configuredChains.yaml
 var embeddedConfiguredChains []byte
 
-var once sync.Once
+var logConfiguredChainsSourceOnce sync.Once
 
 // initBuiltinChainConfig returns an ibc.ChainConfig mapping all configured chains
 func initBuiltinChainConfig(log *zap.Logger) (map[string]ibc.ChainConfig, error) {
@@ -76,11 +76,11 @@ func initBuiltinChainConfig(log *zap.Logger) (map[string]ibc.ChainConfig, error)
 		return nil, fmt.Errorf("error unmarshalling pre-configured chains: %w", err)
 	}
 
-	once.Do(func() {
+	logConfiguredChainsSourceOnce.Do(func() {
 		if val != "" {
 			log.Info("Using user specified configured chains", zap.String("file", val))
 		} else {
-			log.Info("Using embedded configured chains", zap.String("file", "ibctest/configuredChains.yaml"))
+			log.Info("Using embedded configured chains")
 		}
 	})
 

--- a/chainspec.go
+++ b/chainspec.go
@@ -10,12 +10,14 @@ import (
 
 	"github.com/strangelove-ventures/ibctest/v5/ibc"
 	"github.com/strangelove-ventures/ibctest/v5/label"
+	"go.uber.org/zap"
 )
 
 // ChainSpec is a wrapper around an ibc.ChainConfig
 // that allows callers to easily reference one of the built-in chain configs
 // and optionally provide overrides for some settings.
 type ChainSpec struct {
+	log *zap.Logger
 	// Name is the name of the built-in config to use as a basis for this chain spec.
 	// Required unless every other field is set.
 	Name string
@@ -75,9 +77,9 @@ func (s *ChainSpec) Config() (*ibc.ChainConfig, error) {
 		return s.applyConfigOverrides(s.ChainConfig)
 	}
 
-	builtinChainConfigs, err := initBuiltinChainConfig()
+	builtinChainConfigs, err := initBuiltinChainConfig(s.log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get preconfigured chains")
+		return nil, fmt.Errorf("failed to get pre-configured chains: %w", err)
 	}
 
 	// Get built-in config.

--- a/chainspec.go
+++ b/chainspec.go
@@ -17,7 +17,6 @@ import (
 // that allows callers to easily reference one of the built-in chain configs
 // and optionally provide overrides for some settings.
 type ChainSpec struct {
-	log *zap.Logger
 	// Name is the name of the built-in config to use as a basis for this chain spec.
 	// Required unless every other field is set.
 	Name string

--- a/chainspec.go
+++ b/chainspec.go
@@ -75,6 +75,11 @@ func (s *ChainSpec) Config() (*ibc.ChainConfig, error) {
 		return s.applyConfigOverrides(s.ChainConfig)
 	}
 
+	builtinChainConfigs, err := initBuiltinChainConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get preconfigured chains")
+	}
+
 	// Get built-in config.
 	// If chain doesn't have built in config, but is fully configured, register chain label.
 	cfg, ok := builtinChainConfigs[s.Name]

--- a/chainspec.go
+++ b/chainspec.go
@@ -49,7 +49,7 @@ type ChainSpec struct {
 
 // Config returns the underlying ChainConfig,
 // with any overrides applied.
-func (s *ChainSpec) Config() (*ibc.ChainConfig, error) {
+func (s *ChainSpec) Config(log *zap.Logger) (*ibc.ChainConfig, error) {
 	if s.Version == "" {
 		// Version must be set at top-level if not set in inlined config.
 		if len(s.ChainConfig.Images) == 0 || s.ChainConfig.Images[0].Version == "" {
@@ -77,7 +77,7 @@ func (s *ChainSpec) Config() (*ibc.ChainConfig, error) {
 		return s.applyConfigOverrides(s.ChainConfig)
 	}
 
-	builtinChainConfigs, err := initBuiltinChainConfig(s.log)
+	builtinChainConfigs, err := initBuiltinChainConfig(log)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pre-configured chains: %w", err)
 	}

--- a/chainspec_test.go
+++ b/chainspec_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/strangelove-ventures/ibctest/v5"
 	"github.com/strangelove-ventures/ibctest/v5/ibc"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestChainSpec_Config(t *testing.T) {
@@ -18,7 +19,7 @@ func TestChainSpec_Config(t *testing.T) {
 			Version: "v7.0.1",
 		}
 
-		_, err := s.Config()
+		_, err := s.Config(zaptest.NewLogger(t))
 		require.NoError(t, err)
 	})
 
@@ -42,7 +43,7 @@ func TestChainSpec_Config(t *testing.T) {
 			},
 		}
 
-		_, err := s.Config()
+		_, err := s.Config(zaptest.NewLogger(t))
 		require.NoError(t, err)
 	})
 
@@ -53,10 +54,10 @@ func TestChainSpec_Config(t *testing.T) {
 			Version: "v7.0.1",
 		}
 
-		cfg1, err := s.Config()
+		cfg1, err := s.Config(zaptest.NewLogger(t))
 		require.NoError(t, err)
 
-		cfg2, err := s.Config()
+		cfg2, err := s.Config(zaptest.NewLogger(t))
 		require.NoError(t, err)
 
 		diff := cmp.Diff(cfg1, cfg2)
@@ -71,7 +72,7 @@ func TestChainSpec_Config(t *testing.T) {
 				Version: "v7.0.1",
 			}
 
-			cfg, err := s.Config()
+			cfg, err := s.Config(zaptest.NewLogger(t))
 			require.NoError(t, err)
 
 			require.Regexp(t, regexp.MustCompile(`^gaia-\d+$`), cfg.Name)
@@ -86,7 +87,7 @@ func TestChainSpec_Config(t *testing.T) {
 				Version: "v7.0.1",
 			}
 
-			cfg, err := s.Config()
+			cfg, err := s.Config(zaptest.NewLogger(t))
 			require.NoError(t, err)
 
 			require.Equal(t, "mychain", cfg.Name)
@@ -104,7 +105,7 @@ func TestChainSpec_Config(t *testing.T) {
 				ChainID: "g-0000",
 			},
 		}
-		baseCfg, err := baseSpec.Config()
+		baseCfg, err := baseSpec.Config(zaptest.NewLogger(t))
 		require.NoError(t, err)
 
 		t.Run("GasAdjustment", func(t *testing.T) {
@@ -114,7 +115,7 @@ func TestChainSpec_Config(t *testing.T) {
 			s := baseSpec
 			s.GasAdjustment = &g
 
-			cfg, err := s.Config()
+			cfg, err := s.Config(zaptest.NewLogger(t))
 			require.NoError(t, err)
 
 			require.Equal(t, g, cfg.GasAdjustment)
@@ -127,7 +128,7 @@ func TestChainSpec_Config(t *testing.T) {
 			s := baseSpec
 			s.NoHostMount = &m
 
-			cfg, err := s.Config()
+			cfg, err := s.Config(zaptest.NewLogger(t))
 			require.NoError(t, err)
 
 			require.Equal(t, m, cfg.NoHostMount)
@@ -140,7 +141,7 @@ func TestChainSpec_Config(t *testing.T) {
 				Name: "gaia",
 			}
 
-			_, err := s.Config()
+			_, err := s.Config(zaptest.NewLogger(t))
 			require.EqualError(t, err, "ChainSpec.Version must not be empty")
 		})
 
@@ -149,7 +150,7 @@ func TestChainSpec_Config(t *testing.T) {
 				Version: "v1.2.3",
 			}
 
-			_, err := s.Config()
+			_, err := s.Config(zaptest.NewLogger(t))
 			require.EqualError(t, err, "ChainSpec.Name required when not all config fields are set")
 		})
 
@@ -159,7 +160,7 @@ func TestChainSpec_Config(t *testing.T) {
 				Version: "v1.2.3",
 			}
 
-			_, err := s.Config()
+			_, err := s.Config(zaptest.NewLogger(t))
 			require.ErrorContains(t, err, "no chain configuration for invalid_chain (available chains are:")
 		})
 	})

--- a/cmd/ibctest/matrix_test.go
+++ b/cmd/ibctest/matrix_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/strangelove-ventures/ibctest/v5"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 )
 
 // Embed the matrix files as strings since they aren't intended to be changed.
@@ -36,7 +37,7 @@ func TestMatrixValid(t *testing.T) {
 
 			for i, cs := range m.ChainSets {
 				for j, c := range cs {
-					_, err := c.Config()
+					_, err := c.Config(zaptest.NewLogger(t))
 					require.NoErrorf(t, err, "failed to generate config from chainset at index %d-%d", i, j)
 				}
 			}

--- a/configuredChains.yaml
+++ b/configuredChains.yaml
@@ -97,7 +97,7 @@ penumbra:
   gas-adjustment: 1.3
   trusting-period: 672h
   images:
-    - repository: ghcr.io/strangelove-ventures/heighliner/tendermint,
+    - repository: ghcr.io/strangelove-ventures/heighliner/tendermint
       uid-gid: 1025:1025
     - repository: ghcr.io/strangelove-ventures/heighliner/penumbra
       uid-gid: 1025:1025

--- a/configuredChains.yaml
+++ b/configuredChains.yaml
@@ -1,0 +1,99 @@
+agoric:
+  name: agoric
+  type: cosmos
+  bin: agd
+  bech32Prefix: agoric
+  denom: urun
+  gas-prices: 0.01urun
+  gas-adjustment: 1.3
+  trusting-period: 672h
+  images:
+    - repository: ghcr.io/strangelove-ventures/heighliner/agoric
+      uid-gid: 1025:1025
+  no-host-mount: true
+
+composable:
+  name: composable
+  type: polkadot
+  bin: polkadot
+  bech32Prefix: ""
+  denom: uDOT
+  gas-prices: ""
+  gas-adjustment: 0
+  trusting-period: ""
+  images:
+    - repository: ghcr.io/strangelove-ventures/heighliner/polkadot
+      uid-gid: 1025:1025
+    - repository: ghcr.io/strangelove-ventures/heighliner/composable
+      uid-gid: 1025:1025
+
+gaia:
+  name: gaia
+  type: cosmos
+  bin: gaiad
+  bech32Prefix: cosmos
+  denom: uatom
+  gas-prices: 0.01uatom
+  gas-adjustment: 1.3
+  trusting-period: 504h
+  images:
+    - repository: ghcr.io/strangelove-ventures/heighliner/gaia
+      uid-gid: 1025:1025
+  no-host-mount: false
+
+icad:
+  name: icad
+  type: cosmos
+  bin: icad
+  bech32Prefix: cosmos
+  denom: photon
+  gas-prices: 0.0photon
+  gas-adjustment: 1.2
+  trusting-period: 504h
+  images:
+    - repository: ghcr.io/strangelove-ventures/heighliner/icad
+      uid-gid: 1025:1025
+  no-host-mount: false
+
+juno:
+  name: juno
+  type: cosmos
+  bin: junod
+  bech32Prefix: juno
+  denom: ujuno
+  gas-prices: 0.0025ujuno
+  gas-adjustment: 1.3
+  trusting-period: 672h
+  images:
+    - repository: ghcr.io/strangelove-ventures/heighliner/juno
+      uid-gid: 1025:1025
+  no-host-mount: false
+
+osmosis:
+  name: osmosis
+  type: cosmos
+  bin: osmosisd
+  bech32Prefix: osmo
+  denom: uosmo
+  gas-prices: 0.0uosmo
+  gas-adjustment: 1.3
+  trusting-period: 336h
+  images:
+    - repository: ghcr.io/strangelove-ventures/heighliner/osmosis
+      uid-gid: 1025:1025
+  no-host-mount: false
+
+penumbra:
+  name: penumbra
+  type: penumbra
+  bin: tendermint
+  bech32Prefix: penumbra
+  denom: upenumbra
+  gas-prices: 0.0upenumbra
+  gas-adjustment: 1.3
+  trusting-period: 672h
+  images:
+    - repository: ghcr.io/strangelove-ventures/heighliner/tendermint,
+      uid-gid: 1025:1025
+    - repository: ghcr.io/strangelove-ventures/heighliner/penumbra
+      uid-gid: 1025:1025

--- a/configuredChains.yaml
+++ b/configuredChains.yaml
@@ -1,6 +1,6 @@
-## NOTICE: This file gets embeded into ibctest binary
+## NOTICE: This file gets embedded into ibctest binary
 ## Ibctest will check the existence for this file in its cwd and in the parent of the cwd,
-## if it is not found it will resort to the embeded version.
+## if it is not found it will resort to the embedded version.
 
 agoric:
   name: agoric

--- a/configuredChains.yaml
+++ b/configuredChains.yaml
@@ -6,7 +6,7 @@ agoric:
   name: agoric
   type: cosmos
   bin: agd
-  bech32Prefix: agoric
+  bech32-prefix: agoric
   denom: urun
   gas-prices: 0.01urun
   gas-adjustment: 1.3
@@ -20,7 +20,7 @@ composable:
   name: composable
   type: polkadot
   bin: polkadot
-  bech32Prefix: ""
+  bech32-prefix: ""
   denom: uDOT
   gas-prices: ""
   gas-adjustment: 0
@@ -35,7 +35,7 @@ gaia:
   name: gaia
   type: cosmos
   bin: gaiad
-  bech32Prefix: cosmos
+  bech32-prefix: cosmos
   denom: uatom
   gas-prices: 0.01uatom
   gas-adjustment: 1.3
@@ -49,7 +49,7 @@ icad:
   name: icad
   type: cosmos
   bin: icad
-  bech32Prefix: cosmos
+  bech32-prefix: cosmos
   denom: photon
   gas-prices: 0.0photon
   gas-adjustment: 1.2
@@ -63,7 +63,7 @@ juno:
   name: juno
   type: cosmos
   bin: junod
-  bech32Prefix: juno
+  bech32-prefix: juno
   denom: ujuno
   gas-prices: 0.0025ujuno
   gas-adjustment: 1.3
@@ -77,7 +77,7 @@ osmosis:
   name: osmosis
   type: cosmos
   bin: osmosisd
-  bech32Prefix: osmo
+  bech32-prefix: osmo
   denom: uosmo
   gas-prices: 0.0uosmo
   gas-adjustment: 1.3
@@ -91,7 +91,7 @@ penumbra:
   name: penumbra
   type: penumbra
   bin: tendermint
-  bech32Prefix: penumbra
+  bech32-prefix: penumbra
   denom: upenumbra
   gas-prices: 0.0upenumbra
   gas-adjustment: 1.3

--- a/configuredChains.yaml
+++ b/configuredChains.yaml
@@ -1,6 +1,6 @@
-## NOTICE: This file gets embedded into ibctest binary
-## Ibctest will check the existence for this file in its cwd and in the parent of the cwd,
-## if it is not found it will resort to the embedded version.
+## NOTICE: This file gets embedded into ibctest binary.
+## Set the environment variable: CONFIGURED_CHAINS to a path
+## to use custom versions of this file
 
 agoric:
   name: agoric

--- a/configuredChains.yaml
+++ b/configuredChains.yaml
@@ -1,5 +1,5 @@
 ## NOTICE: This file gets embedded into ibctest binary.
-## Set the environment variable: CONFIGURED_CHAINS to a path
+## Set the environment variable: IBCTEST_CONFIGURED_CHAINS to a path
 ## to use custom versions of this file
 
 agoric:

--- a/configuredChains.yaml
+++ b/configuredChains.yaml
@@ -1,3 +1,7 @@
+## NOTICE: This file gets embeded into ibctest binary
+## Ibctest will check the existence for this file in its cwd and in the parent of the cwd,
+## if it is not found it will resort to the embeded version.
+
 agoric:
   name: agoric
   type: cosmos

--- a/docs/conformanceTests.md
+++ b/docs/conformanceTests.md
@@ -38,7 +38,8 @@ By passing in a matrix file you can customize these aspects of the environment:
 
 
 **Pre-Configured Chains**
-`ibctest` comes with [pre-configured chains](./preconfiguredChains.txt). 
+
+`ibctest` comes with [pre-configured chains](../configuredChains.yaml). 
 In the matrix file, if `Name` matches the name of any pre-configured chain, `ibctest` will use standard settings UNLESS overriden in the matrix file. [example_matrix_custom.json](../cmd/ibctest/example_matrix_custom.json) is an example of overriding all options.
 
 

--- a/docs/preconfiguredChains.txt
+++ b/docs/preconfiguredChains.txt
@@ -1,6 +1,0 @@
-gaia
-osmosis
-juno
-agoric
-icad
-penumbra

--- a/docs/writeCustomTests.md
+++ b/docs/writeCustomTests.md
@@ -30,7 +30,7 @@ The chain factory is where you configure your chain binaries.
 
 `ibctest` needs a docker image with the chain binary(s) installed to spin up the local testnet. 
 
-`ibctest` has several [pre-configured chains](./preconfiguredChains.txt). These docker images are pulled from [Heighliner](https://github.com/strangelove-ventures/heighliner) (repository of docker images of many IBC enabled chains). Note that Heighliner needs to have the `Version` you are requesting.
+`ibctest` has several [pre-configured chains](../configuredChains.yaml). These docker images are pulled from [Heighliner](https://github.com/strangelove-ventures/heighliner) (repository of docker images of many IBC enabled chains). Note that Heighliner needs to have the `Version` you are requesting.
 
 When creating your `ChainFactory`, if the `Name` matches the name of a pre-configured chain, the pre-configured settings are used. You can override these settings by passing them into the `ibc.ChainConfig` when initializing your ChainFactory. We do this above with `GasPrices` for gaia.
 

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -9,27 +9,27 @@ import (
 // ChainConfig defines the chain parameters requires to run an ibctest testnet for a chain.
 type ChainConfig struct {
 	// Chain type, e.g. cosmos.
-	Type string
+	Type string `yaml:"type"`
 	// Chain name, e.g. cosmoshub.
-	Name string
+	Name string `yaml:"name"`
 	// Chain ID, e.g. cosmoshub-4
-	ChainID string
+	ChainID string `yaml:"chain-id"`
 	// Docker images required for running chain nodes.
-	Images []DockerImage
+	Images []DockerImage `yaml:"images"`
 	// Binary to execute for the chain node daemon.
-	Bin string
+	Bin string `yaml:"bin"`
 	// Bech32 prefix for chain addresses, e.g. cosmos.
-	Bech32Prefix string
+	Bech32Prefix string `yaml:"bech32Prefix"`
 	// Denomination of native currency, e.g. uatom.
-	Denom string
+	Denom string `yaml:"denom"`
 	// Minimum gas prices for sending transactions, in native currency denom.
-	GasPrices string
+	GasPrices string `yaml:"gas-prices"`
 	// Adjustment multiplier for gas fees.
-	GasAdjustment float64
+	GasAdjustment float64 `yaml:"gas-adjustment"`
 	// Trusting period of the chain.
-	TrustingPeriod string
+	TrustingPeriod string `yaml:"trusting-period"`
 	// Do not use docker host mount.
-	NoHostMount bool
+	NoHostMount bool `yaml:"no-host-mount"`
 	// When provided, genesis file contents will be altered before sharing for genesis.
 	ModifyGenesis func(ChainConfig, []byte) ([]byte, error)
 	// Override config parameters for files at filepath.
@@ -114,9 +114,9 @@ func (c ChainConfig) IsFullyConfigured() bool {
 }
 
 type DockerImage struct {
-	Repository string
-	Version    string
-	UidGid     string
+	Repository string `yaml:"repository"`
+	Version    string `yaml:"version"`
+	UidGid     string `yaml:"uid-gid"`
 }
 
 // Ref returns the reference to use when e.g. creating a container.

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -19,7 +19,7 @@ type ChainConfig struct {
 	// Binary to execute for the chain node daemon.
 	Bin string `yaml:"bin"`
 	// Bech32 prefix for chain addresses, e.g. cosmos.
-	Bech32Prefix string `yaml:"bech32Prefix"`
+	Bech32Prefix string `yaml:"bech32-prefix"`
 	// Denomination of native currency, e.g. uatom.
 	Denom string `yaml:"denom"`
 	// Minimum gas prices for sending transactions, in native currency denom.


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR moves the builtin chains from a hardcoded struct to a yaml file.

This makes it straight forward for testers to view and edit the "preconfigured" settings.


Ibctest will embed ./confiugredChains.yaml. It will refer to this embedded version UNLESS the environment variable  IBCTEST_CONFIGURED_CHAINS is set to a path for "custom" preconfigured chains and settings.


This should satisfy: https://github.com/strangelove-ventures/ibctest/issues/175
