### PR TITLE
fix race conditions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,4 +39,4 @@ jobs:
       # run tests
       - name: run all tests
         # show cosmos chain and relayer logs on test failure
-        run: (go test -timeout 30m -v -p 2 ./...) || (echo "\n\n*****CHAIN and RELAYER LOGS*****" && cat "$HOME/.ibctest/logs/ibctest.log" && exit 1)
+        run: (go test -race -timeout 30m -v -p 2 ./...) || (echo "\n\n*****CHAIN and RELAYER LOGS*****" && cat "$HOME/.ibctest/logs/ibctest.log" && exit 1)

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -787,9 +787,9 @@ func (c *CosmosChain) Timeouts(ctx context.Context, height uint64) ([]ibc.Packet
 
 // FindTxs implements blockdb.BlockSaver.
 func (c *CosmosChain) FindTxs(ctx context.Context, height uint64) ([]blockdb.Tx, error) {
-	c.findTxMu.Lock()
 	fn := c.getFullNode()
-	c.findTxMu.Unlock()
+	c.findTxMu.Lock()
+	defer c.findTxMu.Unlock()
 	return fn.FindTxs(ctx, height)
 }
 

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -819,10 +819,7 @@ func (c *CosmosChain) StartAllNodes(ctx context.Context) error {
 			return n.StartContainer(ctx)
 		})
 	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return eg.Wait()
 }
 
 func (c *CosmosChain) VoteOnProposalAllValidators(ctx context.Context, proposalID string, vote string) error {

--- a/chainspec.go
+++ b/chainspec.go
@@ -43,11 +43,15 @@ type ChainSpec struct {
 	// Generate the automatic suffix on demand when needed.
 	autoSuffixOnce sync.Once
 	autoSuffix     string
+
+	mu sync.Mutex
 }
 
 // Config returns the underlying ChainConfig,
 // with any overrides applied.
 func (s *ChainSpec) Config() (*ibc.ChainConfig, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.Version == "" {
 		// Version must be set at top-level if not set in inlined config.
 		if len(s.ChainConfig.Images) == 0 || s.ChainConfig.Images[0].Version == "" {

--- a/chainspec.go
+++ b/chainspec.go
@@ -45,8 +45,6 @@ type ChainSpec struct {
 	autoSuffix     string
 }
 
-var builtinChainConfigsLock sync.Mutex
-
 // Config returns the underlying ChainConfig,
 // with any overrides applied.
 func (s *ChainSpec) Config() (*ibc.ChainConfig, error) {
@@ -79,8 +77,6 @@ func (s *ChainSpec) Config() (*ibc.ChainConfig, error) {
 
 	// Get built-in config.
 	// If chain doesn't have built in config, but is fully configured, register chain label.
-	builtinChainConfigsLock.Lock()
-	defer builtinChainConfigsLock.Unlock()
 	cfg, ok := builtinChainConfigs[s.Name]
 	if !ok {
 		if !s.ChainConfig.IsFullyConfigured() {
@@ -98,6 +94,8 @@ func (s *ChainSpec) Config() (*ibc.ChainConfig, error) {
 		}
 		cfg = ibc.ChainConfig{}
 	}
+
+	cfg = cfg.Clone()
 
 	// Apply any overrides from this ChainSpec.
 	cfg = cfg.MergeChainSpecConfig(s.ChainConfig)

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -38,6 +38,14 @@ type ChainConfig struct {
 	EncodingConfig *simappparams.EncodingConfig
 }
 
+func (c ChainConfig) Clone() ChainConfig {
+	x := c
+	images := make([]DockerImage, len(c.Images))
+	copy(images, c.Images)
+	x.Images = images
+	return x
+}
+
 func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 	// Make several in-place modifications to c,
 	// which is a value, not a reference,


### PR DESCRIPTION
Fixes potential race condition due to concurrent `cf.Chains` calls here:
https://github.com/strangelove-ventures/ibctest/blob/main/conformance/test.go#L245-L270

Potentially source of startup hang reported by macOS users?

Also fixes a potential race with the block collector trying to collect blocks while the chain is starting back up after the upgrade

Adds race detection to CI