### PR TITLE
Update packet forward test case

### DIFF
--- a/examples/ibc/packet_forward_test.go
+++ b/examples/ibc/packet_forward_test.go
@@ -133,7 +133,7 @@ func TestPacketForwardMiddleware(t *testing.T) {
 	gaiaOsmoChan := osmoChannels[0].Counterparty
 	junoGaiaChan := junoChannels[0]
 	firstHopDenom := transfertypes.GetPrefixedDenom(gaiaOsmoChan.PortID, gaiaOsmoChan.ChannelID, osmosis.Config().Denom)
-	secondHopDenom := transfertypes.GetPrefixedDenom(junoGaiaChan.Counterparty.PortID, junoGaiaChan.Counterparty.ChannelID, firstHopDenom)
+	secondHopDenom := transfertypes.GetPrefixedDenom(junoGaiaChan.PortID, junoGaiaChan.ChannelID, firstHopDenom)
 	dstIbcDenom := transfertypes.ParseDenomTrace(secondHopDenom)
 
 	// Check that the funds sent are present in the acc on juno


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR fixes the composition of the IBC denom used in the second hop of the packet forward test case. Previously we were using the wrong path end when composing the IBC denom which resulted in intermittent failures due to the assertions using an invalid denom. 

## Checklist

- [ ] I have made sure the upstream branch for this PR is correct
- [ ] I have made sure this PR is ready to merge
- [ ] I have made sure that I have assigned reviewers related to this project

