### PR TITLE
feat: Add cosmos message poller

### DIFF
--- a/chain/cosmos/poll.go
+++ b/chain/cosmos/poll.go
@@ -30,6 +30,9 @@ func PollForProposalStatus(ctx context.Context, chain *CosmosChain, startHeight,
 // fn is optional. Return true from the fn to stop polling and return the found message. If fn is nil, returns the first message to match type T.
 func PollForMessage[T any](ctx context.Context, chain *CosmosChain, registry codectypes.InterfaceRegistry, startHeight, maxHeight uint64, fn func(found T) bool) (T, error) {
 	var zero T
+	if fn == nil {
+		fn = func(T) bool { return true }
+	}
 	doPoll := func(ctx context.Context, height uint64) (T, error) {
 		h := int64(height)
 		block, err := chain.getFullNode().Client.Block(ctx, &h)

--- a/chain/cosmos/poll.go
+++ b/chain/cosmos/poll.go
@@ -2,8 +2,10 @@ package cosmos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/strangelove-ventures/ibctest/v6/test"
 )
 
@@ -21,5 +23,35 @@ func PollForProposalStatus(ctx context.Context, chain *CosmosChain, startHeight,
 		return *p, nil
 	}
 	bp := test.BlockPoller[ProposalResponse]{CurrentHeight: chain.Height, PollFunc: doPoll}
+	return bp.DoPoll(ctx, startHeight, maxHeight)
+}
+
+// PollForMessage searches every transaction for a message. Must pass a coded registry capable of decoding the cosmos transaction.
+// fn is optional. Return true from the fn to stop polling and return the found message. If fn is nil, returns the first message to match type T.
+func PollForMessage[T any](ctx context.Context, chain *CosmosChain, registry codectypes.InterfaceRegistry, startHeight, maxHeight uint64, fn func(found T) bool) (T, error) {
+	var zero T
+	doPoll := func(ctx context.Context, height uint64) (T, error) {
+		h := int64(height)
+		block, err := chain.getFullNode().Client.Block(ctx, &h)
+		if err != nil {
+			return zero, err
+		}
+		for _, tx := range block.Block.Txs {
+			sdkTx, err := decodeTX(registry, tx)
+			if err != nil {
+				return zero, err
+			}
+			for _, msg := range sdkTx.GetMsgs() {
+				if found, ok := msg.(T); ok {
+					if fn(found) {
+						return found, nil
+					}
+				}
+			}
+		}
+		return zero, errors.New("not found")
+	}
+
+	bp := test.BlockPoller[T]{CurrentHeight: chain.Height, PollFunc: doPoll}
 	return bp.DoPoll(ctx, startHeight, maxHeight)
 }

--- a/chain/cosmos/poll.go
+++ b/chain/cosmos/poll.go
@@ -10,7 +10,7 @@ import (
 // PollForProposalStatus attempts to find a proposal with matching ID and status.
 func PollForProposalStatus(ctx context.Context, chain *CosmosChain, startHeight, maxHeight uint64, proposalID string, status string) (ProposalResponse, error) {
 	var zero ProposalResponse
-	doPoll := func(ctx context.Context, height uint64) (any, error) {
+	doPoll := func(ctx context.Context, height uint64) (ProposalResponse, error) {
 		p, err := chain.QueryProposal(ctx, proposalID)
 		if err != nil {
 			return zero, err
@@ -20,10 +20,6 @@ func PollForProposalStatus(ctx context.Context, chain *CosmosChain, startHeight,
 		}
 		return *p, nil
 	}
-	bp := test.BlockPoller{CurrentHeight: chain.Height, PollFunc: doPoll}
-	p, err := bp.DoPoll(ctx, startHeight, maxHeight)
-	if err != nil {
-		return zero, err
-	}
-	return p.(ProposalResponse), nil
+	bp := test.BlockPoller[ProposalResponse]{CurrentHeight: chain.Height, PollFunc: doPoll}
+	return bp.DoPoll(ctx, startHeight, maxHeight)
 }

--- a/examples/cosmos/light_client_test.go
+++ b/examples/cosmos/light_client_test.go
@@ -1,0 +1,101 @@
+package cosmos_test
+
+import (
+	"context"
+	"testing"
+
+	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+	"github.com/strangelove-ventures/ibctest/v6"
+	"github.com/strangelove-ventures/ibctest/v6/chain/cosmos"
+	"github.com/strangelove-ventures/ibctest/v6/ibc"
+	"github.com/strangelove-ventures/ibctest/v6/testreporter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestUpdateLightClients(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Chains
+	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
+		{Name: "gaia", Version: gaiaVersion},
+		{Name: "osmosis", Version: osmosisVersion},
+	})
+
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+	gaia, osmosis := chains[0], chains[1]
+
+	// Relayer
+	client, network := ibctest.DockerSetup(t)
+	r := ibctest.NewBuiltinRelayerFactory(ibc.CosmosRly, zaptest.NewLogger(t)).Build(
+		t, client, network)
+
+	ic := ibctest.NewInterchain().
+		AddChain(gaia).
+		AddChain(osmosis).
+		AddRelayer(r, "relayer").
+		AddLink(ibctest.InterchainLink{
+			Chain1:  gaia,
+			Chain2:  osmosis,
+			Relayer: r,
+			Path:    "client-test-path",
+		})
+
+	// Build interchain
+	rep := testreporter.NewNopReporter()
+	eRep := rep.RelayerExecReporter(t)
+	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
+	}))
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
+
+	require.NoError(t, r.StartRelayer(ctx, eRep))
+	t.Cleanup(func() {
+		_ = r.StopRelayer(ctx, eRep)
+	})
+
+	// Create and Fund User Wallets
+	fundAmount := int64(10_000_000)
+	users := ibctest.GetAndFundTestUsers(t, ctx, "default", fundAmount, gaia, osmosis)
+	gaiaUser, osmoUser := users[0], users[1]
+
+	// Get Channel ID
+	gaiaChannelInfo, err := r.GetChannels(ctx, eRep, gaia.Config().ChainID)
+	require.NoError(t, err)
+	chanID := gaiaChannelInfo[0].ChannelID
+
+	height, err := osmosis.Height(ctx)
+	require.NoError(t, err)
+
+	amountToSend := int64(553255) // Unique amount to make log searching easier.
+	dstAddress := osmoUser.Bech32Address(osmosis.Config().Bech32Prefix)
+	tx, err := gaia.SendIBCTransfer(ctx, chanID, gaiaUser.KeyName, ibc.WalletAmount{
+		Address: dstAddress,
+		Denom:   gaia.Config().Denom,
+		Amount:  amountToSend,
+	},
+		nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, tx.Validate())
+
+	chain := osmosis.(*cosmos.CosmosChain)
+	reg := chain.Config().EncodingConfig.InterfaceRegistry
+	msg, err := cosmos.PollForMessage[*clienttypes.MsgUpdateClient](ctx, chain, reg, height, height+10, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "07-tendermint-0", msg.ClientId)
+	require.NotEmpty(t, msg.Signer)
+	// TODO: Assert header information
+}

--- a/examples/cosmos/state_sync_test.go
+++ b/examples/cosmos/state_sync_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestCosmosHubStateSync(t *testing.T) {
-	CosmosChainStateSyncTest(t, "gaia", "v7.0.3")
+	CosmosChainStateSyncTest(t, "gaia", gaiaVersion)
 }
 
 const stateSyncSnapshotInterval = 10

--- a/examples/cosmos/versions_test.go
+++ b/examples/cosmos/versions_test.go
@@ -1,0 +1,6 @@
+package cosmos_test
+
+const (
+	gaiaVersion    = "v7.1.0"
+	osmosisVersion = "v12.2.0"
+)

--- a/examples/ibc/learn_ibc_test.go
+++ b/examples/ibc/learn_ibc_test.go
@@ -21,6 +21,8 @@ func TestLearn(t *testing.T) {
 		t.Skip("skipping in short mode")
 	}
 
+	t.Parallel()
+
 	ctx := context.Background()
 
 	// Chain Factory

--- a/examples/ibc/learn_ibc_test.go
+++ b/examples/ibc/learn_ibc_test.go
@@ -75,7 +75,7 @@ func TestLearn(t *testing.T) {
 
 	// Create and Fund User Wallets
 	fundAmount := int64(10_000_000)
-	users := ibctest.GetAndFundTestUsers(t, ctx, "default", int64(fundAmount), gaia, osmosis)
+	users := ibctest.GetAndFundTestUsers(t, ctx, "default", fundAmount, gaia, osmosis)
 	gaiaUser := users[0]
 	osmosisUser := users[1]
 


### PR DESCRIPTION
Adds a new poll function for cosmos chains. The ability to poll for any arbitrary cosmos message. 

I will use this in the relayer codebase to help with a test regarding keeping light clients up to date. 