### PR TITLE
Integrate coin-type configuration

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -496,7 +496,7 @@ func (tn *ChainNode) CreateKey(ctx context.Context, name string) error {
 
 	_, _, err := tn.ExecBin(ctx,
 		"keys", "add", name,
-		"--coin-type", fmt.Sprint(tn.Chain.Config().CoinType),
+		"--coin-type", tn.Chain.Config().CoinType,
 		"--keyring-backend", keyring.BackendTest,
 	)
 	return err

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -496,6 +496,7 @@ func (tn *ChainNode) CreateKey(ctx context.Context, name string) error {
 
 	_, _, err := tn.ExecBin(ctx,
 		"keys", "add", name,
+		"--coin-type", fmt.Sprint(tn.Chain.Config().CoinType),
 		"--keyring-backend", keyring.BackendTest,
 	)
 	return err
@@ -506,7 +507,7 @@ func (tn *ChainNode) RecoverKey(ctx context.Context, keyName, mnemonic string) e
 	command := []string{
 		"sh",
 		"-c",
-		fmt.Sprintf(`echo %q | %s keys add %s --recover --keyring-backend %s --home %s --output json`, mnemonic, tn.Chain.Config().Bin, keyName, keyring.BackendTest, tn.HomeDir()),
+		fmt.Sprintf(`echo %q | %s keys add %s --recover --keyring-backend %s --coin-type %d --home %s --output json`, mnemonic, tn.Chain.Config().Bin, keyName, keyring.BackendTest, tn.Chain.Config().CoinType, tn.HomeDir()),
 	}
 
 	tn.lock.Lock()
@@ -688,7 +689,7 @@ func (tn *ChainNode) ExecuteContract(ctx context.Context, keyName string, contra
 	return err
 }
 
-// QueryContract performs a smart query, taking in a query struct and returning a error with the response struct populated. 
+// QueryContract performs a smart query, taking in a query struct and returning a error with the response struct populated.
 func (tn *ChainNode) QueryContract(ctx context.Context, contractAddress string, queryMsg any, response any) error {
 	query, err := json.Marshal(queryMsg)
 	if err != nil {

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -507,7 +507,7 @@ func (tn *ChainNode) RecoverKey(ctx context.Context, keyName, mnemonic string) e
 	command := []string{
 		"sh",
 		"-c",
-		fmt.Sprintf(`echo %q | %s keys add %s --recover --keyring-backend %s --coin-type %d --home %s --output json`, mnemonic, tn.Chain.Config().Bin, keyName, keyring.BackendTest, tn.Chain.Config().CoinType, tn.HomeDir()),
+		fmt.Sprintf(`echo %q | %s keys add %s --recover --keyring-backend %s --coin-type %s --home %s --output json`, mnemonic, tn.Chain.Config().Bin, keyName, keyring.BackendTest, tn.Chain.Config().CoinType, tn.HomeDir()),
 	}
 
 	tn.lock.Lock()

--- a/chainspec.go
+++ b/chainspec.go
@@ -106,6 +106,12 @@ func (s *ChainSpec) Config(log *zap.Logger) (*ibc.ChainConfig, error) {
 	// Apply any overrides from this ChainSpec.
 	cfg = cfg.MergeChainSpecConfig(s.ChainConfig)
 
+	coinType, err := cfg.VerifyCoinType()
+	if err != nil {
+		return nil, err
+	}
+	cfg.CoinType = coinType
+
 	// Apply remaining top-level overrides.
 	return s.applyConfigOverrides(cfg)
 }

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -24,10 +24,10 @@ import (
 // but the report will be missing details.
 type Relayer interface {
 	// restore a mnemonic to be used as a relayer wallet for a chain
-	RestoreKey(ctx context.Context, rep RelayerExecReporter, coinType uint32, chainID, keyName, mnemonic string) error
+	RestoreKey(ctx context.Context, rep RelayerExecReporter, chainID, keyName, coinType, mnemonic string) error
 
 	// generate a new key
-	AddKey(ctx context.Context, rep RelayerExecReporter, coinType uint32, chainID, keyName string) (Wallet, error)
+	AddKey(ctx context.Context, rep RelayerExecReporter, chainID, keyName, coinType string) (Wallet, error)
 
 	// GetWallet returns a Wallet for that relayer on the given chain and a boolean indicating if it was found.
 	GetWallet(chainID string) (Wallet, bool)

--- a/ibc/relayer.go
+++ b/ibc/relayer.go
@@ -24,10 +24,10 @@ import (
 // but the report will be missing details.
 type Relayer interface {
 	// restore a mnemonic to be used as a relayer wallet for a chain
-	RestoreKey(ctx context.Context, rep RelayerExecReporter, chainID, keyName, mnemonic string) error
+	RestoreKey(ctx context.Context, rep RelayerExecReporter, coinType uint32, chainID, keyName, mnemonic string) error
 
 	// generate a new key
-	AddKey(ctx context.Context, rep RelayerExecReporter, chainID, keyName string) (Wallet, error)
+	AddKey(ctx context.Context, rep RelayerExecReporter, coinType uint32, chainID, keyName string) (Wallet, error)
 
 	// GetWallet returns a Wallet for that relayer on the given chain and a boolean indicating if it was found.
 	GetWallet(chainID string) (Wallet, bool)

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -26,7 +26,7 @@ type ChainConfig struct {
 	// Denomination of native currency, e.g. uatom.
 	Denom string `yaml:"denom"`
 	// Coin type
-	CoinType uint32 `default:"118" yaml:"coin-type"`
+	CoinType string `default:"118" yaml:"coin-type"`
 	// Minimum gas prices for sending transactions, in native currency denom.
 	GasPrices string `yaml:"gas-prices"`
 	// Adjustment multiplier for gas fees.
@@ -52,18 +52,22 @@ func (c ChainConfig) Clone() ChainConfig {
 }
 
 func (c ChainConfig) VerifyCoinType() (uint32, error) {
-	if c.CoinType == 0 {
+	if c.CoinType == "" {
 		typ := reflect.TypeOf(c)
 		f, _ := typ.FieldByName("CoinType")
 		coinTypeS := f.Tag.Get("default")
-		u64, err := strconv.ParseUint(coinTypeS, 0, 32)
+		u64, err := strconv.ParseUint(coinTypeS, 10, 32)
 		if err != nil {
 			return 0, err
 		}
 		u32 := uint32(u64)
 		return u32, nil
 	} else {
-		return c.CoinType, nil
+		u64, err := strconv.ParseUint(c.CoinType, 10, 32)
+		if err != nil {
+			return 0, err
+		}
+		return uint32(u64), nil
 	}
 
 }

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -51,23 +51,22 @@ func (c ChainConfig) Clone() ChainConfig {
 	return x
 }
 
-func (c ChainConfig) VerifyCoinType() (uint32, error) {
+func (c ChainConfig) VerifyCoinType() (string, error) {
 	if c.CoinType == "" {
 		typ := reflect.TypeOf(c)
 		f, _ := typ.FieldByName("CoinType")
-		coinTypeS := f.Tag.Get("default")
-		u64, err := strconv.ParseUint(coinTypeS, 10, 32)
+		coinType := f.Tag.Get("default")
+		_, err := strconv.ParseUint(coinType, 10, 32)
 		if err != nil {
-			return 0, err
+			return "", err
 		}
-		u32 := uint32(u64)
-		return u32, nil
+		return coinType, nil
 	} else {
-		u64, err := strconv.ParseUint(c.CoinType, 10, 32)
+		_, err := strconv.ParseUint(c.CoinType, 10, 32)
 		if err != nil {
-			return 0, err
+			return "", err
 		}
-		return uint32(u64), nil
+		return c.CoinType, nil
 	}
 
 }
@@ -103,7 +102,7 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 		c.Denom = other.Denom
 	}
 
-	if other.CoinType != 0 {
+	if other.CoinType != "" {
 		c.CoinType = other.CoinType
 	}
 

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -52,6 +52,8 @@ func (c ChainConfig) Clone() ChainConfig {
 }
 
 func (c ChainConfig) VerifyCoinType() (string, error) {
+	// If coin-type is left blank in the ChainConfig,
+	// the Cosmos SDK default of 118 is used.
 	if c.CoinType == "" {
 		typ := reflect.TypeOf(c)
 		f, _ := typ.FieldByName("CoinType")
@@ -68,7 +70,6 @@ func (c ChainConfig) VerifyCoinType() (string, error) {
 		}
 		return c.CoinType, nil
 	}
-
 }
 
 func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {

--- a/interchain.go
+++ b/interchain.go
@@ -3,6 +3,7 @@ package ibctest
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -421,8 +422,9 @@ func (ic *Interchain) configureRelayerKeys(ctx context.Context, rep *testreporte
 			}
 
 			if err := r.RestoreKey(ctx,
-				rep, c.Config().CoinType,
+				rep,
 				c.Config().ChainID, chainName,
+				c.Config().CoinType,
 				ic.relayerWallets[relayerChain{R: r, C: c}].Mnemonic,
 			); err != nil {
 				return fmt.Errorf("failed to restore key to relayer %s for chain %s: %w", ic.relayers[r], chainName, err)
@@ -442,7 +444,11 @@ type relayerChain struct {
 // BuildWallet will generate a random key for the key name in the provided keyring.
 // Returns the mnemonic and address in the bech32 format of the provided ChainConfig.
 func BuildWallet(kr keyring.Keyring, keyName string, config ibc.ChainConfig) ibc.Wallet {
-	coinType := config.CoinType
+	coinTypeU64, err := strconv.ParseUint(config.CoinType, 10, 32)
+	if err != nil {
+		panic(fmt.Errorf("invalid coin type: %w", err))
+	}
+	coinType := uint32(coinTypeU64)
 
 	info, mnemonic, err := kr.NewMnemonic(
 		keyName,

--- a/interchain.go
+++ b/interchain.go
@@ -421,7 +421,7 @@ func (ic *Interchain) configureRelayerKeys(ctx context.Context, rep *testreporte
 			}
 
 			if err := r.RestoreKey(ctx,
-				rep,
+				rep, c.Config().CoinType,
 				c.Config().ChainID, chainName,
 				ic.relayerWallets[relayerChain{R: r, C: c}].Mnemonic,
 			); err != nil {
@@ -442,9 +442,7 @@ type relayerChain struct {
 // BuildWallet will generate a random key for the key name in the provided keyring.
 // Returns the mnemonic and address in the bech32 format of the provided ChainConfig.
 func BuildWallet(kr keyring.Keyring, keyName string, config ibc.ChainConfig) ibc.Wallet {
-	// NOTE: this is hardcoded to the cosmos coin type.
-	// In the future, we may need to get the coin type from the chain config.
-	const coinType = types.CoinType
+	coinType := config.CoinType
 
 	info, mnemonic, err := kr.NewMnemonic(
 		keyName,
@@ -463,9 +461,9 @@ func BuildWallet(kr keyring.Keyring, keyName string, config ibc.ChainConfig) ibc
 	}
 
 	return ibc.Wallet{
-		Address: types.MustBech32ifyAddressBytes(config.Bech32Prefix, addr.Bytes()),
-
+		Address:  types.MustBech32ifyAddressBytes(config.Bech32Prefix, addr.Bytes()),
 		Mnemonic: mnemonic,
+		CoinType: coinType,
 	}
 }
 

--- a/interchain.go
+++ b/interchain.go
@@ -444,16 +444,15 @@ type relayerChain struct {
 // BuildWallet will generate a random key for the key name in the provided keyring.
 // Returns the mnemonic and address in the bech32 format of the provided ChainConfig.
 func BuildWallet(kr keyring.Keyring, keyName string, config ibc.ChainConfig) ibc.Wallet {
-	coinTypeU64, err := strconv.ParseUint(config.CoinType, 10, 32)
+	coinType, err := strconv.ParseUint(config.CoinType, 10, 32)
 	if err != nil {
 		panic(fmt.Errorf("invalid coin type: %w", err))
 	}
-	coinType := uint32(coinTypeU64)
 
 	info, mnemonic, err := kr.NewMnemonic(
 		keyName,
 		keyring.English,
-		hd.CreateHDPath(coinType, 0, 0).String(),
+		hd.CreateHDPath(uint32(coinType), 0, 0).String(),
 		"", // Empty passphrase.
 		hd.Secp256k1,
 	)
@@ -469,7 +468,7 @@ func BuildWallet(kr keyring.Keyring, keyName string, config ibc.ChainConfig) ibc
 	return ibc.Wallet{
 		Address:  types.MustBech32ifyAddressBytes(config.Bech32Prefix, addr.Bytes()),
 		Mnemonic: mnemonic,
-		CoinType: coinType,
+		CoinType: uint32(coinType),
 	}
 }
 

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -189,8 +189,8 @@ func (r *DockerRelayer) generateConfigTar(relativeConfigPath string, content []b
 	return &buf, nil
 }
 
-func (r *DockerRelayer) AddKey(ctx context.Context, rep ibc.RelayerExecReporter, chainID, keyName string) (ibc.Wallet, error) {
-	cmd := r.c.AddKey(chainID, keyName, r.HomeDir())
+func (r *DockerRelayer) AddKey(ctx context.Context, rep ibc.RelayerExecReporter, coinType uint32, chainID, keyName string) (ibc.Wallet, error) {
+	cmd := r.c.AddKey(chainID, keyName, r.HomeDir(), coinType)
 
 	// Adding a key should be near-instantaneous, so add a 1-minute timeout
 	// to detect if Docker has hung.
@@ -317,8 +317,8 @@ func (r *DockerRelayer) Exec(ctx context.Context, rep ibc.RelayerExecReporter, c
 	}
 }
 
-func (r *DockerRelayer) RestoreKey(ctx context.Context, rep ibc.RelayerExecReporter, chainID, keyName, mnemonic string) error {
-	cmd := r.c.RestoreKey(chainID, keyName, mnemonic, r.HomeDir())
+func (r *DockerRelayer) RestoreKey(ctx context.Context, rep ibc.RelayerExecReporter, coinType uint32, chainID, keyName, mnemonic string) error {
+	cmd := r.c.RestoreKey(chainID, keyName, mnemonic, r.HomeDir(), coinType)
 
 	// Restoring a key should be near-instantaneous, so add a 1-minute timeout
 	// to detect if Docker has hung.
@@ -644,7 +644,7 @@ type RelayerCommander interface {
 	// The remaining methods produce the command to run inside the container.
 
 	AddChainConfiguration(containerFilePath, homeDir string) []string
-	AddKey(chainID, keyName, homeDir string) []string
+	AddKey(chainID, keyName, homeDir string, coinType uint32) []string
 	CreateChannel(pathName string, opts ibc.CreateChannelOptions, homeDir string) []string
 	CreateClients(pathName string, opts ibc.CreateClientOptions, homeDir string) []string
 	CreateConnections(pathName, homeDir string) []string
@@ -655,7 +655,7 @@ type RelayerCommander interface {
 	GetChannels(chainID, homeDir string) []string
 	GetConnections(chainID, homeDir string) []string
 	LinkPath(pathName, homeDir string, channelOpts ibc.CreateChannelOptions, clientOpts ibc.CreateClientOptions) []string
-	RestoreKey(chainID, keyName, mnemonic, homeDir string) []string
+	RestoreKey(chainID, keyName, mnemonic, homeDir string, coinType uint32) []string
 	StartRelayer(homeDir string, pathNames ...string) []string
 	UpdateClients(pathName, homeDir string) []string
 }

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -189,8 +189,8 @@ func (r *DockerRelayer) generateConfigTar(relativeConfigPath string, content []b
 	return &buf, nil
 }
 
-func (r *DockerRelayer) AddKey(ctx context.Context, rep ibc.RelayerExecReporter, coinType uint32, chainID, keyName string) (ibc.Wallet, error) {
-	cmd := r.c.AddKey(chainID, keyName, r.HomeDir(), coinType)
+func (r *DockerRelayer) AddKey(ctx context.Context, rep ibc.RelayerExecReporter, chainID, keyName, coinType string) (ibc.Wallet, error) {
+	cmd := r.c.AddKey(chainID, keyName, coinType, r.HomeDir())
 
 	// Adding a key should be near-instantaneous, so add a 1-minute timeout
 	// to detect if Docker has hung.
@@ -317,8 +317,8 @@ func (r *DockerRelayer) Exec(ctx context.Context, rep ibc.RelayerExecReporter, c
 	}
 }
 
-func (r *DockerRelayer) RestoreKey(ctx context.Context, rep ibc.RelayerExecReporter, coinType uint32, chainID, keyName, mnemonic string) error {
-	cmd := r.c.RestoreKey(chainID, keyName, mnemonic, r.HomeDir(), coinType)
+func (r *DockerRelayer) RestoreKey(ctx context.Context, rep ibc.RelayerExecReporter, chainID, keyName, coinType, mnemonic string) error {
+	cmd := r.c.RestoreKey(chainID, keyName, coinType, mnemonic, r.HomeDir())
 
 	// Restoring a key should be near-instantaneous, so add a 1-minute timeout
 	// to detect if Docker has hung.
@@ -644,7 +644,7 @@ type RelayerCommander interface {
 	// The remaining methods produce the command to run inside the container.
 
 	AddChainConfiguration(containerFilePath, homeDir string) []string
-	AddKey(chainID, keyName, homeDir string, coinType uint32) []string
+	AddKey(chainID, keyName, coinType, homeDir string) []string
 	CreateChannel(pathName string, opts ibc.CreateChannelOptions, homeDir string) []string
 	CreateClients(pathName string, opts ibc.CreateClientOptions, homeDir string) []string
 	CreateConnections(pathName, homeDir string) []string
@@ -655,7 +655,7 @@ type RelayerCommander interface {
 	GetChannels(chainID, homeDir string) []string
 	GetConnections(chainID, homeDir string) []string
 	LinkPath(pathName, homeDir string, channelOpts ibc.CreateChannelOptions, clientOpts ibc.CreateClientOptions) []string
-	RestoreKey(chainID, keyName, mnemonic, homeDir string, coinType uint32) []string
+	RestoreKey(chainID, keyName, coinType, mnemonic, homeDir string) []string
 	StartRelayer(homeDir string, pathNames ...string) []string
 	UpdateClients(pathName, homeDir string) []string
 }

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -115,7 +115,7 @@ func (commander) AddChainConfiguration(containerFilePath, homeDir string) []stri
 	}
 }
 
-func (commander) AddKey(chainID, keyName, homeDir string, coinType uint32) []string {
+func (commander) AddKey(chainID, keyName, coinType, homeDir string) []string {
 	return []string{
 		"rly", "keys", "add", chainID, keyName,
 		"--coin-type", fmt.Sprint(coinType), "--home", homeDir,
@@ -213,7 +213,7 @@ func (commander) LinkPath(pathName, homeDir string, channelOpts ibc.CreateChanne
 	}
 }
 
-func (commander) RestoreKey(chainID, keyName, mnemonic, homeDir string, coinType uint32) []string {
+func (commander) RestoreKey(chainID, keyName, coinType, mnemonic, homeDir string) []string {
 	return []string{
 		"rly", "keys", "restore", chainID, keyName, mnemonic,
 		"--coin-type", fmt.Sprint(coinType), "--home", homeDir,

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -4,6 +4,7 @@ package rly
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -114,10 +115,10 @@ func (commander) AddChainConfiguration(containerFilePath, homeDir string) []stri
 	}
 }
 
-func (commander) AddKey(chainID, keyName, homeDir string) []string {
+func (commander) AddKey(chainID, keyName, homeDir string, coinType uint32) []string {
 	return []string{
 		"rly", "keys", "add", chainID, keyName,
-		"--home", homeDir,
+		"--coin-type", fmt.Sprint(coinType), "--home", homeDir,
 	}
 }
 
@@ -212,10 +213,10 @@ func (commander) LinkPath(pathName, homeDir string, channelOpts ibc.CreateChanne
 	}
 }
 
-func (commander) RestoreKey(chainID, keyName, mnemonic, homeDir string) []string {
+func (commander) RestoreKey(chainID, keyName, mnemonic, homeDir string, coinType uint32) []string {
 	return []string{
 		"rly", "keys", "restore", chainID, keyName, mnemonic,
-		"--home", homeDir,
+		"--coin-type", fmt.Sprint(coinType), "--home", homeDir,
 	}
 }
 


### PR DESCRIPTION
The PR adds the ability to specify Coin Types when creating or restoring keys for chains. 

The coinType is invoked in the chainConfig but defaults to "118" (Cosmos SDK default) if the key:value pair is left blank.