### PR TITLE
fix: remove redundant ValidateBasic check in BroadcastTx

### DIFF
--- a/chain/cosmos/broadcaster.go
+++ b/chain/cosmos/broadcaster.go
@@ -182,12 +182,6 @@ func (b *Broadcaster) defaultTxFactory(clientCtx client.Context, accountNumber u
 // BroadcastTx uses the provided Broadcaster to broadcast all the provided messages which will be signed
 // by the User provided. The sdk.TxResponse and an error are returned.
 func BroadcastTx(ctx context.Context, broadcaster *Broadcaster, broadcastingUser User, msgs ...sdk.Msg) (sdk.TxResponse, error) {
-	for _, msg := range msgs {
-		if err := msg.ValidateBasic(); err != nil {
-			return sdk.TxResponse{}, err
-		}
-	}
-
 	f, err := broadcaster.GetFactory(ctx, broadcastingUser)
 	if err != nil {
 		return sdk.TxResponse{}, err


### PR DESCRIPTION
this check is redundant because ValidateBasic on the messages will be run by the chain binary anyway, running it prematurely leads to strange version issues 

context: writing an e2e test for upgrading ibc-go v6 -> v7 runs automatic migrations which bump the client and consensusstate versions of the tendermint client and solo machine, we would need the msg to be broadcasted and validated by the v6 binary rather than the v7 code.