### PR TITLE
Update penumbra key management

### DIFF
--- a/chain/penumbra/penumbra_app_node.go
+++ b/chain/penumbra/penumbra_app_node.go
@@ -67,7 +67,20 @@ func (p *PenumbraAppNode) HomeDir() string {
 }
 
 func (p *PenumbraAppNode) CreateKey(ctx context.Context, keyName string) error {
-	cmd := []string{"pcli", "-d", p.HomeDir(), "wallet", "generate"}
+	keyPath := filepath.Join(p.HomeDir(), "keys", keyName)
+	cmd := []string{"pcli", "-d", keyPath, "keys", "generate"}
+	_, stderr, err := p.Exec(ctx, cmd, nil)
+	// already exists error is okay
+	if err != nil && !strings.Contains(string(stderr), "already exists, refusing to overwrite it") {
+		return err
+	}
+	return nil
+}
+
+// RecoverKey restores a key from a given mnemonic.
+func (p *PenumbraAppNode) RecoverKey(ctx context.Context, keyName, mnemonic string) error {
+	keyPath := filepath.Join(p.HomeDir(), "keys", keyName)
+	cmd := []string{"pcli", "-d", keyPath, "keys", "import", "phrase", mnemonic}
 	_, stderr, err := p.Exec(ctx, cmd, nil)
 	// already exists error is okay
 	if err != nil && !strings.Contains(string(stderr), "already exists, refusing to overwrite it") {
@@ -78,10 +91,11 @@ func (p *PenumbraAppNode) CreateKey(ctx context.Context, keyName string) error {
 
 // initializes validator definition template file
 // wallet must be generated first
-func (p *PenumbraAppNode) InitValidatorFile(ctx context.Context) error {
+func (p *PenumbraAppNode) InitValidatorFile(ctx context.Context, valKeyName string) error {
+	keyPath := filepath.Join(p.HomeDir(), "keys", valKeyName)
 	cmd := []string{
 		"pcli",
-		"-d", p.HomeDir(),
+		"-d", keyPath,
 		"validator", "definition", "template",
 		"--file", p.ValidatorDefinitionTemplateFilePathContainer(),
 	}

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -143,7 +143,7 @@ func (c *PenumbraChain) CreateKey(ctx context.Context, keyName string) error {
 }
 
 func (c *PenumbraChain) RecoverKey(ctx context.Context, name, mnemonic string) error {
-	return fmt.Errorf("RecoverKey not implemented for PenumbraChain")
+	return c.getRelayerNode().PenumbraAppNode.RecoverKey(ctx, name, mnemonic)
 }
 
 // Implements Chain interface
@@ -375,7 +375,7 @@ func (c *PenumbraChain) Start(testName string, ctx context.Context, additionalGe
 			if err := v.PenumbraAppNode.CreateKey(egCtx, valKey); err != nil {
 				return fmt.Errorf("error generating wallet on penumbra node: %v", err)
 			}
-			if err := v.PenumbraAppNode.InitValidatorFile(egCtx); err != nil {
+			if err := v.PenumbraAppNode.InitValidatorFile(egCtx, valKey); err != nil {
 				return fmt.Errorf("error initializing validator template on penumbra node: %v", err)
 			}
 

--- a/examples/penumbra/penumbra_chain_test.go
+++ b/examples/penumbra/penumbra_chain_test.go
@@ -24,7 +24,7 @@ func TestPenumbraChainStart(t *testing.T) {
 	chains, err := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
 		{
 			Name:    "penumbra",
-			Version: "033-eirene,v0.34.21",
+			Version: "040-themisto.1,v0.34.21",
 			ChainConfig: ibc.ChainConfig{
 				ChainID: "penumbra-1",
 			},


### PR DESCRIPTION
Since penumbra doesn't have "key names", we'll have the folder that houses the key act as the key name.