### PR TITLE
fix: add randomized suffix to relayer container names to avoid naming collisions

### DIFF
--- a/examples/cosmos/chain_upgrade_ibc_test.go
+++ b/examples/cosmos/chain_upgrade_ibc_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	ibctest "github.com/strangelove-ventures/ibctest/v3"
+	"github.com/strangelove-ventures/ibctest/v3"
 	"github.com/strangelove-ventures/ibctest/v3/chain/cosmos"
 	"github.com/strangelove-ventures/ibctest/v3/conformance"
 	"github.com/strangelove-ventures/ibctest/v3/ibc"
@@ -80,11 +80,10 @@ func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeV
 	rep := testreporter.NewNopReporter()
 
 	require.NoError(t, ic.Build(ctx, rep.RelayerExecReporter(t), ibctest.InterchainBuildOptions{
-		TestName:          t.Name(),
-		Client:            client,
-		NetworkID:         network,
-		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
-		SkipPathCreation:  false,
+		TestName:         t.Name(),
+		Client:           client,
+		NetworkID:        network,
+		SkipPathCreation: false,
 	}))
 	t.Cleanup(func() {
 		_ = ic.Close()

--- a/examples/cosmos/chain_upgrade_ibc_test.go
+++ b/examples/cosmos/chain_upgrade_ibc_test.go
@@ -80,9 +80,10 @@ func CosmosChainUpgradeIBCTest(t *testing.T, chainName, initialVersion, upgradeV
 	rep := testreporter.NewNopReporter()
 
 	require.NoError(t, ic.Build(ctx, rep.RelayerExecReporter(t), ibctest.InterchainBuildOptions{
-		TestName:         t.Name(),
-		Client:           client,
-		NetworkID:        network,
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
+		// BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
 		SkipPathCreation: false,
 	}))
 	t.Cleanup(func() {

--- a/examples/cosmos/chain_upgrade_test.go
+++ b/examples/cosmos/chain_upgrade_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/icza/dyno"
-	ibctest "github.com/strangelove-ventures/ibctest/v3"
+	"github.com/strangelove-ventures/ibctest/v3"
 	"github.com/strangelove-ventures/ibctest/v3/chain/cosmos"
 	"github.com/strangelove-ventures/ibctest/v3/ibc"
 	"github.com/strangelove-ventures/ibctest/v3/testutil"
@@ -57,11 +57,10 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeVers
 	client, network := ibctest.DockerSetup(t)
 
 	require.NoError(t, ic.Build(ctx, nil, ibctest.InterchainBuildOptions{
-		TestName:          t.Name(),
-		Client:            client,
-		NetworkID:         network,
-		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
-		SkipPathCreation:  true,
+		TestName:         t.Name(),
+		Client:           client,
+		NetworkID:        network,
+		SkipPathCreation: true,
 	}))
 	t.Cleanup(func() {
 		_ = ic.Close()

--- a/examples/cosmos/chain_upgrade_test.go
+++ b/examples/cosmos/chain_upgrade_test.go
@@ -57,9 +57,10 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeVers
 	client, network := ibctest.DockerSetup(t)
 
 	require.NoError(t, ic.Build(ctx, nil, ibctest.InterchainBuildOptions{
-		TestName:         t.Name(),
-		Client:           client,
-		NetworkID:        network,
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
+		// BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
 		SkipPathCreation: true,
 	}))
 	t.Cleanup(func() {

--- a/examples/cosmos/state_sync_test.go
+++ b/examples/cosmos/state_sync_test.go
@@ -70,9 +70,10 @@ func CosmosChainStateSyncTest(t *testing.T, chainName, version string) {
 	client, network := ibctest.DockerSetup(t)
 
 	require.NoError(t, ic.Build(ctx, nil, ibctest.InterchainBuildOptions{
-		TestName:         t.Name(),
-		Client:           client,
-		NetworkID:        network,
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
+		// BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
 		SkipPathCreation: true,
 	}))
 	t.Cleanup(func() {

--- a/examples/cosmos/state_sync_test.go
+++ b/examples/cosmos/state_sync_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	ibctest "github.com/strangelove-ventures/ibctest/v3"
+	"github.com/strangelove-ventures/ibctest/v3"
 	"github.com/strangelove-ventures/ibctest/v3/chain/cosmos"
 	"github.com/strangelove-ventures/ibctest/v3/ibc"
 	"github.com/strangelove-ventures/ibctest/v3/testutil"
@@ -70,11 +70,10 @@ func CosmosChainStateSyncTest(t *testing.T, chainName, version string) {
 	client, network := ibctest.DockerSetup(t)
 
 	require.NoError(t, ic.Build(ctx, nil, ibctest.InterchainBuildOptions{
-		TestName:          t.Name(),
-		Client:            client,
-		NetworkID:         network,
-		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
-		SkipPathCreation:  true,
+		TestName:         t.Name(),
+		Client:           client,
+		NetworkID:        network,
+		SkipPathCreation: true,
 	}))
 	t.Cleanup(func() {
 		_ = ic.Close()

--- a/examples/ibc/learn_ibc_test.go
+++ b/examples/ibc/learn_ibc_test.go
@@ -67,6 +67,7 @@ func TestLearn(t *testing.T) {
 		TestName:  t.Name(),
 		Client:    client,
 		NetworkID: network,
+		// BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
 
 		SkipPathCreation: false},
 	),

--- a/examples/ibc/learn_ibc_test.go
+++ b/examples/ibc/learn_ibc_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
-	ibctest "github.com/strangelove-ventures/ibctest/v3"
+	"github.com/strangelove-ventures/ibctest/v3"
 	"github.com/strangelove-ventures/ibctest/v3/ibc"
 	"github.com/strangelove-ventures/ibctest/v3/testreporter"
 	"github.com/stretchr/testify/require"
@@ -64,10 +64,9 @@ func TestLearn(t *testing.T) {
 
 	// Build interchain
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
-		TestName:          t.Name(),
-		Client:            client,
-		NetworkID:         network,
-		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
 
 		SkipPathCreation: false},
 	),

--- a/examples/ibc/packet_forward_test.go
+++ b/examples/ibc/packet_forward_test.go
@@ -47,10 +47,10 @@ func TestPacketForwardMiddleware(t *testing.T) {
 	chainID_A, chainID_B, chainID_C, chainID_D := "chain-a", "chain-b", "chain-c", "chain-d"
 
 	cf := ibctest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*ibctest.ChainSpec{
-		{Name: "gaia", Version: "justin-forward_middleware_v3_refactor", ChainConfig: ibc.ChainConfig{ChainID: chainID_A, GasPrices: "0.0uatom"}},
-		{Name: "gaia", Version: "justin-forward_middleware_v3_refactor", ChainConfig: ibc.ChainConfig{ChainID: chainID_B, GasPrices: "0.0uatom"}},
-		{Name: "gaia", Version: "justin-forward_middleware_v3_refactor", ChainConfig: ibc.ChainConfig{ChainID: chainID_C, GasPrices: "0.0uatom"}},
-		{Name: "gaia", Version: "justin-forward_middleware_v3_refactor", ChainConfig: ibc.ChainConfig{ChainID: chainID_D, GasPrices: "0.0uatom"}},
+		{Name: "gaia", Version: "v8.0.0-rc3", ChainConfig: ibc.ChainConfig{ChainID: chainID_A, GasPrices: "0.0uatom"}},
+		{Name: "gaia", Version: "v8.0.0-rc3", ChainConfig: ibc.ChainConfig{ChainID: chainID_B, GasPrices: "0.0uatom"}},
+		{Name: "gaia", Version: "v8.0.0-rc3", ChainConfig: ibc.ChainConfig{ChainID: chainID_C, GasPrices: "0.0uatom"}},
+		{Name: "gaia", Version: "v8.0.0-rc3", ChainConfig: ibc.ChainConfig{ChainID: chainID_D, GasPrices: "0.0uatom"}},
 	})
 
 	chains, err := cf.Chains(t.Name())
@@ -95,9 +95,10 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		})
 
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
-		TestName:  t.Name(),
-		Client:    client,
-		NetworkID: network,
+		TestName:          t.Name(),
+		Client:            client,
+		NetworkID:         network,
+		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
 
 		SkipPathCreation: false,
 	}))
@@ -614,5 +615,51 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		require.Equal(t, transferAmount, baEscrowBalance)
 		require.Equal(t, int64(0), bcEscrowBalance)
 		require.Equal(t, int64(0), cdEscrowBalance)
+	})
+
+	t.Run("forward a->b->a", func(t *testing.T) {
+		// Send packet from Chain A->Chain B->Chain A
+
+		userABalance, err := chainA.GetBalance(ctx, userA.Bech32Address(chainA.Config().Bech32Prefix), chainA.Config().Denom)
+		require.NoError(t, err, "failed to get user a balance")
+
+		userBBalance, err := chainB.GetBalance(ctx, userB.Bech32Address(chainB.Config().Bech32Prefix), firstHopDenom)
+		require.NoError(t, err, "failed to get user a balance")
+
+		transfer := ibc.WalletAmount{
+			Address: userB.Bech32Address(chainB.Config().Bech32Prefix),
+			Denom:   chainA.Config().Denom,
+			Amount:  transferAmount,
+		}
+
+		firstHopMetadata := &PacketMetadata{
+			Forward: &ForwardMetadata{
+				Receiver: userA.Bech32Address(chainA.Config().Bech32Prefix),
+				Channel:  baChan.ChannelID,
+				Port:     baChan.PortID,
+			},
+		}
+
+		memo, err := json.Marshal(firstHopMetadata)
+		require.NoError(t, err)
+
+		chainAHeight, err := chainA.Height(ctx)
+		require.NoError(t, err)
+
+		transferTx, err := chainA.SendIBCTransfer(ctx, abChan.ChannelID, userA.KeyName, transfer, ibc.TransferOptions{Memo: string(memo)})
+		require.NoError(t, err)
+		_, err = testutil.PollForAck(ctx, chainA, chainAHeight, chainAHeight+30, transferTx.Packet)
+		require.NoError(t, err)
+		err = testutil.WaitForBlocks(ctx, 1, chainA)
+		require.NoError(t, err)
+
+		chainABalance, err := chainA.GetBalance(ctx, userA.Bech32Address(chainA.Config().Bech32Prefix), chainA.Config().Denom)
+		require.NoError(t, err)
+
+		chainBBalance, err := chainB.GetBalance(ctx, userB.Bech32Address(chainB.Config().Bech32Prefix), firstHopIBCDenom)
+		require.NoError(t, err)
+
+		require.Equal(t, userABalance, chainABalance)
+		require.Equal(t, userBBalance, chainBBalance)
 	})
 }

--- a/examples/ibc/packet_forward_test.go
+++ b/examples/ibc/packet_forward_test.go
@@ -95,10 +95,9 @@ func TestPacketForwardMiddleware(t *testing.T) {
 		})
 
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
-		TestName:          t.Name(),
-		Client:            client,
-		NetworkID:         network,
-		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
 
 		SkipPathCreation: false,
 	}))

--- a/examples/ibc/wasm/wasm_ibc_test.go
+++ b/examples/ibc/wasm/wasm_ibc_test.go
@@ -66,9 +66,10 @@ func TestWasmIbc(t *testing.T) {
 
 	// Build interchain
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
-		TestName:         t.Name(),
-		Client:           client,
-		NetworkID:        network,
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
+		// BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
 		SkipPathCreation: false,
 	}))
 	t.Cleanup(func() {

--- a/examples/ibc/wasm/wasm_ibc_test.go
+++ b/examples/ibc/wasm/wasm_ibc_test.go
@@ -66,11 +66,10 @@ func TestWasmIbc(t *testing.T) {
 
 	// Build interchain
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
-		TestName:          t.Name(),
-		Client:            client,
-		NetworkID:         network,
-		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
-		SkipPathCreation:  false,
+		TestName:         t.Name(),
+		Client:           client,
+		NetworkID:        network,
+		SkipPathCreation: false,
 	}))
 	t.Cleanup(func() {
 		_ = ic.Close()

--- a/examples/ibc/wasm/wasm_icq_test.go
+++ b/examples/ibc/wasm/wasm_icq_test.go
@@ -129,11 +129,10 @@ func TestInterchainQueriesWASM(t *testing.T) {
 
 	logger.Info("ic.Build()")
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
-		TestName:          t.Name(),
-		Client:            client,
-		NetworkID:         network,
-		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
-		SkipPathCreation:  false,
+		TestName:         t.Name(),
+		Client:           client,
+		NetworkID:        network,
+		SkipPathCreation: false,
 	}))
 
 	// Wait a few blocks for user accounts to be created on chain

--- a/examples/ibc/wasm/wasm_icq_test.go
+++ b/examples/ibc/wasm/wasm_icq_test.go
@@ -129,9 +129,10 @@ func TestInterchainQueriesWASM(t *testing.T) {
 
 	logger.Info("ic.Build()")
 	require.NoError(t, ic.Build(ctx, eRep, ibctest.InterchainBuildOptions{
-		TestName:         t.Name(),
-		Client:           client,
-		NetworkID:        network,
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
+		// BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
 		SkipPathCreation: false,
 	}))
 

--- a/examples/osmosis/cosmos_chain_expedited_proposal_test.go
+++ b/examples/osmosis/cosmos_chain_expedited_proposal_test.go
@@ -54,9 +54,10 @@ func TestOsmosisExpeditedProposal(t *testing.T) {
 	client, network := ibctest.DockerSetup(t)
 
 	require.NoError(t, ic.Build(ctx, nil, ibctest.InterchainBuildOptions{
-		TestName:         t.Name(),
-		Client:           client,
-		NetworkID:        network,
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
+		// BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
 		SkipPathCreation: true,
 	}))
 	t.Cleanup(func() {

--- a/examples/osmosis/cosmos_chain_expedited_proposal_test.go
+++ b/examples/osmosis/cosmos_chain_expedited_proposal_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/icza/dyno"
-	ibctest "github.com/strangelove-ventures/ibctest/v3"
+	"github.com/strangelove-ventures/ibctest/v3"
 	"github.com/strangelove-ventures/ibctest/v3/chain/cosmos"
 	"github.com/strangelove-ventures/ibctest/v3/examples/osmosis"
 	"github.com/strangelove-ventures/ibctest/v3/ibc"
@@ -54,11 +54,10 @@ func TestOsmosisExpeditedProposal(t *testing.T) {
 	client, network := ibctest.DockerSetup(t)
 
 	require.NoError(t, ic.Build(ctx, nil, ibctest.InterchainBuildOptions{
-		TestName:          t.Name(),
-		Client:            client,
-		NetworkID:         network,
-		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
-		SkipPathCreation:  true,
+		TestName:         t.Name(),
+		Client:           client,
+		NetworkID:        network,
+		SkipPathCreation: true,
 	}))
 	t.Cleanup(func() {
 		_ = ic.Close()

--- a/examples/osmosis/cosmos_chain_gamm_pool_test.go
+++ b/examples/osmosis/cosmos_chain_gamm_pool_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 
 	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
-	ibctest "github.com/strangelove-ventures/ibctest/v3"
+	"github.com/strangelove-ventures/ibctest/v3"
 	"github.com/strangelove-ventures/ibctest/v3/chain/cosmos"
 	"github.com/strangelove-ventures/ibctest/v3/examples/osmosis"
 	"github.com/strangelove-ventures/ibctest/v3/ibc"
 	"github.com/strangelove-ventures/ibctest/v3/relayer"
-	"github.com/strangelove-ventures/ibctest/v3/test"
 	"github.com/strangelove-ventures/ibctest/v3/testreporter"
+	"github.com/strangelove-ventures/ibctest/v3/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
@@ -78,11 +78,10 @@ func TestOsmosisGammPool(t *testing.T) {
 	rep := testreporter.NewNopReporter().RelayerExecReporter(t)
 
 	require.NoError(t, ic.Build(ctx, rep, ibctest.InterchainBuildOptions{
-		TestName:          t.Name(),
-		Client:            client,
-		NetworkID:         network,
-		BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
-		SkipPathCreation:  false,
+		TestName:         t.Name(),
+		Client:           client,
+		NetworkID:        network,
+		SkipPathCreation: false,
 	}))
 	t.Cleanup(func() {
 		_ = ic.Close()
@@ -114,14 +113,14 @@ func TestOsmosisGammPool(t *testing.T) {
 		Address: chainUserBech32,
 		Amount:  counterpartyAmountSent,
 		Denom:   counterpartyDenom,
-	}, nil)
+	}, ibc.TransferOptions{})
 	require.NoError(t, err)
 
 	// will use this later for balance assertions
 	counterpartyIBCTransferFees := counterpartyChain.GetGasFeesInNativeDenom(tx.GasSpent)
 
 	// wait for packet flow to complete.
-	_, err = test.PollForAck(ctx, counterpartyChain, counterpartyHeight, counterpartyHeight+10, tx.Packet)
+	_, err = testutil.PollForAck(ctx, counterpartyChain, counterpartyHeight, counterpartyHeight+10, tx.Packet)
 	require.NoError(t, err)
 
 	// get ibc denom for counterparty denom on chain.
@@ -169,10 +168,10 @@ func TestOsmosisGammPool(t *testing.T) {
 		Address: counterpartyUserBech32,
 		Amount:  ibcDenomBalance,
 		Denom:   ibcDenom,
-	}, nil)
+	}, ibc.TransferOptions{})
 	require.NoError(t, err)
 
-	_, err = test.PollForAck(ctx, chain, chainHeight, chainHeight+10, tx.Packet)
+	_, err = testutil.PollForAck(ctx, chain, chainHeight, chainHeight+10, tx.Packet)
 	require.NoError(t, err)
 
 	ibcDenomBalancePostReturn, err := chain.GetBalance(ctx, chainUserBech32, ibcDenom)

--- a/examples/osmosis/cosmos_chain_gamm_pool_test.go
+++ b/examples/osmosis/cosmos_chain_gamm_pool_test.go
@@ -78,9 +78,10 @@ func TestOsmosisGammPool(t *testing.T) {
 	rep := testreporter.NewNopReporter().RelayerExecReporter(t)
 
 	require.NoError(t, ic.Build(ctx, rep, ibctest.InterchainBuildOptions{
-		TestName:         t.Name(),
-		Client:           client,
-		NetworkID:        network,
+		TestName:  t.Name(),
+		Client:    client,
+		NetworkID: network,
+		// BlockDatabaseFile: ibctest.DefaultBlockDatabaseFilepath(),
 		SkipPathCreation: false,
 	}))
 	t.Cleanup(func() {

--- a/relayer/docker.go
+++ b/relayer/docker.go
@@ -413,7 +413,7 @@ func (r *DockerRelayer) pullContainerImageIfNecessary(containerImage ibc.DockerI
 func (r *DockerRelayer) createNodeContainer(ctx context.Context, pathNames ...string) error {
 	containerImage := r.containerImage()
 	joinedPaths := strings.Join(pathNames, ".")
-	containerName := fmt.Sprintf("%s-%s", r.c.Name(), joinedPaths)
+	containerName := fmt.Sprintf("%s-%s-%s", r.c.Name(), joinedPaths, dockerutil.RandLowerCaseLetterString(5))
 	cmd := r.c.StartRelayer(r.HomeDir(), pathNames...)
 	r.log.Info(
 		"Running command",


### PR DESCRIPTION
When running multiple tests in parallel you hit a container name collision error if you are running a relayer on paths with the same names across those tests. This PR adds a random 5 character suffix to the relayer container names to avoid this ever happening.

Closes #375 