### PR TITLE
PreGenesis hooks

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -801,12 +801,12 @@ func (tn *ChainNode) ExportState(ctx context.Context, height int64) (string, err
 	tn.lock.Lock()
 	defer tn.lock.Unlock()
 
-	_, stderr, err := tn.ExecBin(ctx, "export", "--height", fmt.Sprint(height))
+	stdout, stderr, err := tn.ExecBin(ctx, "export", "--height", fmt.Sprint(height))
 	if err != nil {
 		return "", err
 	}
-	// output comes to stderr for some reason
-	return string(stderr), nil
+	// output comes to stderr on older versions
+	return string(stdout) + string(stderr), nil
 }
 
 func (tn *ChainNode) UnsafeResetAll(ctx context.Context) error {

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -596,7 +596,7 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 					return err
 				}
 			}
-			if c.cfg.SkipGenTx == nil || !*c.cfg.SkipGenTx {
+			if !c.cfg.SkipGenTx {
 				return v.InitValidatorGenTx(ctx, &chainCfg, genesisAmounts, genesisSelfDelegation)
 			}
 			return nil
@@ -659,7 +659,7 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 			return err
 		}
 
-		if c.cfg.SkipGenTx == nil || !*c.cfg.SkipGenTx {
+		if !c.cfg.SkipGenTx {
 			if err := validatorN.copyGentx(ctx, validator0); err != nil {
 				return err
 			}
@@ -672,7 +672,7 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 		}
 	}
 
-	if c.cfg.SkipGenTx == nil || !*c.cfg.SkipGenTx {
+	if !c.cfg.SkipGenTx {
 		if err := validator0.CollectGentxs(ctx); err != nil {
 			return err
 		}

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -596,7 +596,10 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 					return err
 				}
 			}
-			return v.InitValidatorGenTx(ctx, &chainCfg, genesisAmounts, genesisSelfDelegation)
+			if c.cfg.SkipGenTx != nil && *c.cfg.SkipGenTx == false {
+				return v.InitValidatorGenTx(ctx, &chainCfg, genesisAmounts, genesisSelfDelegation)
+			}
+			return nil
 		})
 	}
 

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -629,16 +629,16 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 		})
 	}
 
+	// wait for this to finish
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
 	if c.cfg.PreGenesis != nil {
 		err := c.cfg.PreGenesis(chainCfg)
 		if err != nil {
 			return err
 		}
-	}
-
-	// wait for this to finish
-	if err := eg.Wait(); err != nil {
-		return err
 	}
 
 	// for the validators we need to collect the gentxs and the accounts
@@ -656,8 +656,10 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 			return err
 		}
 
-		if err := validatorN.copyGentx(ctx, validator0); err != nil {
-			return err
+		if c.cfg.SkipGenTx != nil && *c.cfg.SkipGenTx == false {
+			if err := validatorN.copyGentx(ctx, validator0); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -667,8 +669,10 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 		}
 	}
 
-	if err := validator0.CollectGentxs(ctx); err != nil {
-		return err
+	if c.cfg.SkipGenTx != nil && *c.cfg.SkipGenTx == false {
+		if err := validator0.CollectGentxs(ctx); err != nil {
+			return err
+		}
 	}
 
 	genbz, err := validator0.GenesisFileContent(ctx)

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -596,7 +596,7 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 					return err
 				}
 			}
-			if c.cfg.SkipGenTx != nil && *c.cfg.SkipGenTx == false {
+			if c.cfg.SkipGenTx == nil || !*c.cfg.SkipGenTx {
 				return v.InitValidatorGenTx(ctx, &chainCfg, genesisAmounts, genesisSelfDelegation)
 			}
 			return nil
@@ -659,7 +659,7 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 			return err
 		}
 
-		if c.cfg.SkipGenTx != nil && *c.cfg.SkipGenTx == false {
+		if c.cfg.SkipGenTx == nil || !*c.cfg.SkipGenTx {
 			if err := validatorN.copyGentx(ctx, validator0); err != nil {
 				return err
 			}
@@ -672,7 +672,7 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 		}
 	}
 
-	if c.cfg.SkipGenTx != nil && *c.cfg.SkipGenTx == false {
+	if c.cfg.SkipGenTx == nil || !*c.cfg.SkipGenTx {
 		if err := validator0.CollectGentxs(ctx); err != nil {
 			return err
 		}

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -629,6 +629,13 @@ func (c *CosmosChain) Start(testName string, ctx context.Context, additionalGene
 		})
 	}
 
+	if c.cfg.PreGenesis != nil {
+		err := c.cfg.PreGenesis(chainCfg)
+		if err != nil {
+			return err
+		}
+	}
+
 	// wait for this to finish
 	if err := eg.Wait(); err != nil {
 		return err

--- a/chainspec.go
+++ b/chainspec.go
@@ -138,8 +138,8 @@ func (s *ChainSpec) applyConfigOverrides(cfg ibc.ChainConfig) (*ibc.ChainConfig,
 	if s.NoHostMount != nil {
 		cfg.NoHostMount = *s.NoHostMount
 	}
-	if s.SkipGenTx != nil {
-		cfg.SkipGenTx = s.SkipGenTx
+	if s.SkipGenTx {
+		cfg.SkipGenTx = true
 	}
 	if s.ModifyGenesis != nil {
 		cfg.ModifyGenesis = s.ModifyGenesis

--- a/chainspec.go
+++ b/chainspec.go
@@ -138,6 +138,9 @@ func (s *ChainSpec) applyConfigOverrides(cfg ibc.ChainConfig) (*ibc.ChainConfig,
 	if s.NoHostMount != nil {
 		cfg.NoHostMount = *s.NoHostMount
 	}
+	if s.SkipGenTx != nil {
+		cfg.SkipGenTx = s.SkipGenTx
+	}
 	if s.ModifyGenesis != nil {
 		cfg.ModifyGenesis = s.ModifyGenesis
 	}

--- a/chainspec.go
+++ b/chainspec.go
@@ -141,6 +141,9 @@ func (s *ChainSpec) applyConfigOverrides(cfg ibc.ChainConfig) (*ibc.ChainConfig,
 	if s.ModifyGenesis != nil {
 		cfg.ModifyGenesis = s.ModifyGenesis
 	}
+	if s.PreGenesis != nil {
+		cfg.PreGenesis = s.PreGenesis
+	}
 
 	// Set the version depending on the chain type.
 	switch cfg.Type {

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -36,7 +36,7 @@ type ChainConfig struct {
 	// Do not use docker host mount.
 	NoHostMount bool `yaml:"no-host-mount"`
 	// When true, will skip validator gentx flow
-	SkipGenTx *bool
+	SkipGenTx bool
 	// When provided, will run before performing gentx and genesis file creation steps for validators.
 	PreGenesis func(ChainConfig) error
 	// When provided, genesis file contents will be altered before sharing for genesis.
@@ -129,8 +129,8 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 		c.ModifyGenesis = other.ModifyGenesis
 	}
 
-	if other.SkipGenTx != nil {
-		c.SkipGenTx = other.SkipGenTx
+	if other.SkipGenTx {
+		c.SkipGenTx = true
 	}
 
 	if other.PreGenesis != nil {

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -35,6 +35,8 @@ type ChainConfig struct {
 	TrustingPeriod string `yaml:"trusting-period"`
 	// Do not use docker host mount.
 	NoHostMount bool `yaml:"no-host-mount"`
+	// When provided, will run before performing gentx and genesis file creation steps for validators.
+	PreGenesis func(ChainConfig) error
 	// When provided, genesis file contents will be altered before sharing for genesis.
 	ModifyGenesis func(ChainConfig, []byte) ([]byte, error)
 	// Override config parameters for files at filepath.
@@ -123,6 +125,10 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 
 	if other.ModifyGenesis != nil {
 		c.ModifyGenesis = other.ModifyGenesis
+	}
+
+	if other.PreGenesis != nil {
+		c.PreGenesis = other.PreGenesis
 	}
 
 	if other.ConfigFileOverrides != nil {

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -35,6 +35,8 @@ type ChainConfig struct {
 	TrustingPeriod string `yaml:"trusting-period"`
 	// Do not use docker host mount.
 	NoHostMount bool `yaml:"no-host-mount"`
+	// When true, will skip validator gentx flow
+	SkipGenTx *bool
 	// When provided, will run before performing gentx and genesis file creation steps for validators.
 	PreGenesis func(ChainConfig) error
 	// When provided, genesis file contents will be altered before sharing for genesis.
@@ -125,6 +127,10 @@ func (c ChainConfig) MergeChainSpecConfig(other ChainConfig) ChainConfig {
 
 	if other.ModifyGenesis != nil {
 		c.ModifyGenesis = other.ModifyGenesis
+	}
+
+	if other.SkipGenTx != nil {
+		c.SkipGenTx = other.SkipGenTx
 	}
 
 	if other.PreGenesis != nil {

--- a/interchain.go
+++ b/interchain.go
@@ -455,6 +455,7 @@ func BuildWallet(kr keyring.Keyring, keyName string, config ibc.ChainConfig) ibc
 	}
 
 	return ibc.Wallet{
+		KeyName: keyName,
 		Address: types.MustBech32ifyAddressBytes(config.Bech32Prefix, info.GetAddress().Bytes()),
 
 		Mnemonic: mnemonic,


### PR DESCRIPTION
Adds `PreGenesis` hook to execute a function prior to genesis file creation. Adds `SkipGenTx` to skip validator gentx flow.

This is utilized currently in our consumer chain tests.